### PR TITLE
Enable C# 8 features for net472 projects

### DIFF
--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Publishing.Core.Tests</RootNamespace>
     <AssemblyName>Publishing.Core.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Publishing.Integration.Tests</RootNamespace>
     <AssemblyName>Publishing.Integration.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>


### PR DESCRIPTION
## Summary
- allow nullable reference types by explicitly enabling C# 8.0

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4baa3548320947cdb03b3fad8ed