### PR TITLE
Fix SqlClient references and expose database class

### DIFF
--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Офіційний SQL-клієнт для .NET 6 -->
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Domain\" />
     <Folder Include="Interfaces\" />
     <Folder Include="Services\" />

--- a/src/Publishing.Core/Services/SqlParameterBuilder.cs
+++ b/src/Publishing.Core/Services/SqlParameterBuilder.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Publishing.Core.Services
 {

--- a/src/Publishing.UI/DataBase.cs
+++ b/src/Publishing.UI/DataBase.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Data;
 
 namespace Publishing
 {
-    internal class DataBase
+    public static class DataBase
     {
         public static string connectString;
 

--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Windows.Forms;
 
 namespace Publishing

--- a/src/Publishing.UI/Forms/deleteOrderForm.cs
+++ b/src/Publishing.UI/Forms/deleteOrderForm.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Windows.Forms;
 
 namespace Publishing

--- a/src/Publishing.UI/Forms/loginForm.cs
+++ b/src/Publishing.UI/Forms/loginForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Windows.Forms;
 
 namespace Publishing

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 

--- a/src/Publishing.UI/Forms/statisticForm.cs
+++ b/src/Publishing.UI/Forms/statisticForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Windows.Forms;
 
 namespace Publishing

--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -56,6 +56,9 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="Microsoft.Data.SqlClient">
+      <HintPath>packages\Microsoft.Data.SqlClient.5.1.0\lib\net472\Microsoft.Data.SqlClient.dll</HintPath>
+    </Reference>
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />

--- a/src/Publishing.UI/packages.config
+++ b/src/Publishing.UI/packages.config
@@ -5,4 +5,5 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="Microsoft.Data.SqlClient" version="5.1.0" targetFramework="net472" />
 </packages>

--- a/src/tests/Publishing.Core.Tests/SqlParameterBuilderTests.cs
+++ b/src/tests/Publishing.Core.Tests/SqlParameterBuilderTests.cs
@@ -2,7 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Publishing.Core.Services;
 using System.Collections.Generic;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace Publishing.Core.Tests

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -2,7 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Reflection;
 using BCrypt.Net;
 

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -2,7 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Reflection;
 
 namespace Publishing.Integration.Tests

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Publishing.UI\Publishing.UI.csproj" />

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Reflection;
 
 namespace Publishing.Integration.Tests


### PR DESCRIPTION
## Summary
- add Microsoft.Data.SqlClient package to Publishing.Core
- expose `Publishing.DataBase` and update SqlClient namespace
- update forms and tests to use Microsoft.Data.SqlClient
- include SqlClient package for UI and tests

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc3322c88320b97c0e33ddf76904