### PR TITLE
Fix connection issues for local SQL Server

### DIFF
--- a/src/Publishing.UI/DataBase.cs
+++ b/src/Publishing.UI/DataBase.cs
@@ -16,7 +16,10 @@ namespace Publishing
 
         public static void OpenConnection()
         {
-            connectString = @"Data Source=" + SQLServerName + ";Initial Catalog=" + dataBaseName + ";Integrated Security=true";
+            connectString =
+                @"Data Source=" + SQLServerName +
+                ";Initial Catalog=" + dataBaseName +
+                ";Integrated Security=true;Encrypt=True;TrustServerCertificate=True";
 
             sqlConnection = new SqlConnection(connectString);
 
@@ -25,7 +28,12 @@ namespace Publishing
 
         public static void OpenConnection(string login, string password)
         {
-            connectString = @"Data Source=" + SQLServerName + ";Initial Catalog=" + dataBaseName + ";User ID=" + login + ";Password=" + password + ";";
+            connectString =
+                @"Data Source=" + SQLServerName +
+                ";Initial Catalog=" + dataBaseName +
+                ";User ID=" + login +
+                ";Password=" + password +
+                ";Encrypt=True;TrustServerCertificate=True";
 
             sqlConnection = new SqlConnection(connectString);
 

--- a/src/Publishing.UI/Forms/loginForm.cs
+++ b/src/Publishing.UI/Forms/loginForm.cs
@@ -10,7 +10,18 @@ namespace Publishing
         public loginForm()
         {
             InitializeComponent();
-            DataBase.OpenConnection();
+            try
+            {
+                DataBase.OpenConnection();
+            }
+            catch (SqlException ex)
+            {
+                MessageBox.Show(
+                    "Не вдалося з'єднатися з базою: " + ex.Message,
+                    "Помилка",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
         }
 
         private void button1_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- trust the SQL server certificate in the connection string
- show a friendly error message when connection fails

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852c41aca1c83209a3dceb62797338a