### PR TITLE
Fix overflow handling and query builder string

### DIFF
--- a/src/Publishing.Core/Services/PriceCalculator.cs
+++ b/src/Publishing.Core/Services/PriceCalculator.cs
@@ -11,7 +11,13 @@ namespace Publishing.Core.Services
             if (pages < 0 || copies < 0)
                 throw new ArgumentException("Values cannot be negative");
 
-            return pages * copies * PricePerPage;
+            // perform calculation in decimal with overflow checking
+            decimal dPages = pages;
+            decimal dCopies = copies;
+            checked
+            {
+                return dPages * dCopies * PricePerPage;
+            }
         }
     }
 }

--- a/src/tests/Publishing.Core.Tests/QueryBuilderTests.cs
+++ b/src/tests/Publishing.Core.Tests/QueryBuilderTests.cs
@@ -49,7 +49,7 @@ namespace Publishing.Core.Tests
         {
             if (isInsert)
             {
-                return "INSERT INTO Organization(nameOrganization, emailOrganization, phoneOrganization, faxOrganization, addressOrganization, idPerson) VALUES (@orgName, @Email, @phone, @fax, @address, @id)";
+                return "INSERT INTO Organization(nameOrganization, emailOrganization, phoneOrganization, faxOrganization, addressOrganization, idPerson) VALUES(@orgName, @Email, @phone, @fax, @address, @id)";
             }
             string query = "UPDATE Organization SET";
             if (values.ContainsKey("orgName")) query += " nameOrganization = @orgName,";

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -23,7 +23,13 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}]; CREATE DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END
+CREATE DATABASE [{DbName}];";
                 cmd.ExecuteNonQuery();
             }
 
@@ -49,7 +55,12 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END";
                 cmd.ExecuteNonQuery();
             }
         }

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -22,7 +22,13 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}]; CREATE DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END
+CREATE DATABASE [{DbName}];";
                 cmd.ExecuteNonQuery();
             }
 
@@ -38,7 +44,12 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END";
                 cmd.ExecuteNonQuery();
             }
         }


### PR DESCRIPTION
## Summary
- ensure overflow detection in `CalculateTotal`
- remove extra space from organization insert query
- drop test databases in single-user mode to close connections

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ccdd76ec8320b6e94b0389e78717