### PR TITLE
Fix StatisticTests database removal

### DIFF
--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -21,7 +21,13 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}]; CREATE DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END
+CREATE DATABASE [{DbName}];";
                 cmd.ExecuteNonQuery();
             }
 
@@ -47,7 +53,12 @@ namespace Publishing.Integration.Tests
             {
                 con.Open();
                 using var cmd = con.CreateCommand();
-                cmd.CommandText = $"IF DB_ID('{DbName}') IS NOT NULL DROP DATABASE [{DbName}];";
+                cmd.CommandText = $@"
+IF DB_ID('{DbName}') IS NOT NULL
+BEGIN
+    ALTER DATABASE [{DbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE [{DbName}];
+END";
                 cmd.ExecuteNonQuery();
             }
         }


### PR DESCRIPTION
## Summary
- ensure StatisticTests drops database even when active
- use `ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE` prior to drop

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d188f6dc83209b84d80e1f5962eb