### PR TITLE
Fix decimal DataRow parameters in tests

### DIFF
--- a/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
@@ -8,9 +8,9 @@ namespace Publishing.Core.Tests
     public class PriceCalculatorTests
     {
         [DataTestMethod]
-        [DataRow(10, 3, 75)]
-        [DataRow(0, 5, 0)]
-        [DataRow(5, 0, 0)]
+        [DataRow(10, 3, 75m)]
+        [DataRow(0, 5, 0m)]
+        [DataRow(5, 0, 0m)]
         public void CalculateTotal_ReturnsExpected(int pages, int copies, decimal expected)
         {
             var result = PriceCalculator.CalculateTotal(pages, copies);


### PR DESCRIPTION
## Summary
- ensure MSTest uses decimal literals in `PriceCalculatorTests`

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852d40e17b8832080955b18db12f776