### PR TITLE
Fix DataRow decimals

### DIFF
--- a/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
@@ -8,11 +8,12 @@ namespace Publishing.Core.Tests
     public class PriceCalculatorTests
     {
         [DataTestMethod]
-        [DataRow(10, 3, 75m)]
-        [DataRow(0, 5, 0m)]
-        [DataRow(5, 0, 0m)]
-        public void CalculateTotal_ReturnsExpected(int pages, int copies, decimal expected)
+        [DataRow(10, 3, 75.0)]
+        [DataRow(0, 5, 0.0)]
+        [DataRow(5, 0, 0.0)]
+        public void CalculateTotal_ReturnsExpected(int pages, int copies, double expectedD)
         {
+            var expected = (decimal)expectedD;
             var result = PriceCalculator.CalculateTotal(pages, copies);
             Assert.AreEqual(expected, result);
         }


### PR DESCRIPTION
## Summary
- fix usage of decimal constants in MSTest DataRow attributes

## Testing
- `dotnet test --no-build -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d53fe10483209ca26a72379e5e71