### PR TITLE
Fix PriceCalculator test isolation

### DIFF
--- a/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
@@ -7,6 +7,13 @@ namespace Publishing.Core.Tests
     [TestClass]
     public class PriceCalculatorTests
     {
+        [TestInitialize]
+        public void Init()
+        {
+            // reset to default price before each test to avoid cross-test contamination
+            PriceCalculator.PricePerPage = 2.5m;
+        }
+
         [DataTestMethod]
         [DataRow(10, 3, 75.0)]
         [DataRow(0, 5, 0.0)]
@@ -24,7 +31,6 @@ namespace Publishing.Core.Tests
             PriceCalculator.PricePerPage = 0m;
             var result = PriceCalculator.CalculateTotal(10, 2);
             Assert.AreEqual(0m, result);
-            PriceCalculator.PricePerPage = 2.5m;
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- reset `PricePerPage` before each test to avoid contamination
- simplify zero-price test cleanup

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852df08167083208c5be692f743cd4c