### PR TITLE
Fix incompatible UI reference in integration tests

### DIFF
--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -11,7 +11,4 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Publishing.UI\Publishing.UI.csproj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove Publishing.UI project reference from integration tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853103ed2608320a4be3f5d9dcd3428