### PR TITLE
Handle null DTOs in CreateOrder

### DIFF
--- a/src/Publishing.Core/Services/OrderService.cs
+++ b/src/Publishing.Core/Services/OrderService.cs
@@ -32,6 +32,8 @@ namespace Publishing.Core.Services
 
         public Order CreateOrder(CreateOrderDto dto)
         {
+            if (dto is null)
+                throw new ArgumentNullException(nameof(dto));
             _validator.Validate(dto);
 
             decimal price = CalculatePrice(dto.Pages, dto.Tirage);


### PR DESCRIPTION
## Summary
- guard against null `CreateOrderDto` in `OrderService.CreateOrder`

## Testing
- `dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685347d2df4083208e185c3e96c381d0