### PR TITLE
Implement zero checks in PriceCalculator

### DIFF
--- a/src/Publishing.Core/Services/PriceCalculator.cs
+++ b/src/Publishing.Core/Services/PriceCalculator.cs
@@ -8,8 +8,15 @@ namespace Publishing.Core.Services
     {
         public decimal Calculate(int pages, int copies, decimal pricePerPage)
         {
-            if (pages < 0 || copies < 0)
-                throw new ArgumentException("Values cannot be negative");
+            if (pages < 0)
+                throw new ArgumentException("Value cannot be negative", nameof(pages));
+            if (copies < 0)
+                throw new ArgumentException("Value cannot be negative", nameof(copies));
+            if (pricePerPage < 0)
+                throw new ArgumentException("Value cannot be negative", nameof(pricePerPage));
+
+            if (pages == 0 || copies == 0 || pricePerPage == 0m)
+                return 0m;
 
             decimal dPages = pages;
             decimal dCopies = copies;

--- a/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
@@ -16,20 +16,24 @@ namespace Publishing.Core.Tests
         }
 
         [DataTestMethod]
-        [DataRow(10, 3, 75.0)]
-        [DataRow(0, 5, 0.0)]
-        [DataRow(5, 0, 0.0)]
-        public void CalculateTotal_ReturnsExpected(int pages, int copies, double expectedD)
+        [DataRow(10, 3, 2.5, 75.0)]
+        [DataRow(1, 1, 1.0, 1.0)]
+        public void CalculateTotal_ReturnsExpected(int pages, int copies, double price, double expectedD)
         {
             var expected = (decimal)expectedD;
-            var result = _calculator.Calculate(pages, copies, 2.5m);
+            var result = _calculator.Calculate(pages, copies, (decimal)price);
             Assert.AreEqual(expected, result);
         }
 
-        [TestMethod]
-        public void CalculateTotal_ZeroPricePerPage_ReturnsZero()
+        [DataTestMethod]
+        [DataRow(0, 5, 2.5)]
+        [DataRow(5, 0, 2.5)]
+        [DataRow(5, 5, 0.0)]
+        [DataRow(int.MaxValue, 0, double.MaxValue)]
+        [DataRow(0, int.MaxValue, double.MaxValue)]
+        public void CalculateTotal_ZeroParameter_ReturnsZero(int pages, int copies, double price)
         {
-            var result = _calculator.Calculate(10, 2, 0m);
+            var result = _calculator.Calculate(pages, copies, (decimal)price);
             Assert.AreEqual(0m, result);
         }
 
@@ -40,11 +44,14 @@ namespace Publishing.Core.Tests
             _calculator.Calculate(int.MaxValue, int.MaxValue, decimal.MaxValue);
         }
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(-1, 1, 1.0)]
+        [DataRow(1, -1, 1.0)]
+        [DataRow(1, 1, -1.0)]
         [ExpectedException(typeof(ArgumentException))]
-        public void CalculateTotal_Negative_Throws()
+        public void CalculateTotal_Negative_Throws(int pages, int copies, double price)
         {
-            _calculator.Calculate(-1, 1, 2.5m);
+            _calculator.Calculate(pages, copies, (decimal)price);
         }
     }
 }


### PR DESCRIPTION
## Summary
- return `0` early when any price calculation parameter is `0`
- extend zero-parameter test cases with extreme values

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534fdaaa988320b7c78d582c7e542e