### PR TITLE
Fix overflow in price zero-case tests

### DIFF
--- a/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/PriceCalculatorTests.cs
@@ -29,8 +29,6 @@ namespace Publishing.Core.Tests
         [DataRow(0, 5, 2.5)]
         [DataRow(5, 0, 2.5)]
         [DataRow(5, 5, 0.0)]
-        [DataRow(int.MaxValue, 0, double.MaxValue)]
-        [DataRow(0, int.MaxValue, double.MaxValue)]
         public void CalculateTotal_ZeroParameter_ReturnsZero(int pages, int copies, double price)
         {
             var result = _calculator.Calculate(pages, copies, (decimal)price);


### PR DESCRIPTION
## Summary
- remove invalid double.MaxValue test rows from `PriceCalculatorTests`

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853569c2e788320a91c5e4a579452d2