### PR TITLE
Fix project references and add BCrypt package

### DIFF
--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Publishing.Core/Services/AuthService.cs
+++ b/src/Publishing.Core/Services/AuthService.cs
@@ -1,4 +1,5 @@
 using System;
+using BCrypt.Net;
 using Publishing.Core.DTOs;
 using Publishing.Core.Interfaces;
 


### PR DESCRIPTION
## Summary
- add BCrypt.Net-Next dependency in Publishing.Core
- import BCrypt.Net in AuthService so BCrypt functions resolve

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535f7a26288320b2793772ff219b60