### PR TITLE
Fix test stubs and integration context

### DIFF
--- a/src/tests/Publishing.Core.Tests/ExceptionFlowTests.cs
+++ b/src/tests/Publishing.Core.Tests/ExceptionFlowTests.cs
@@ -13,6 +13,19 @@ namespace Publishing.Core.Tests
         private class StubOrderRepository : IOrderRepository
         {
             public void Save(Order order) { }
+
+            public Task UpdateExpiredAsync() => Task.CompletedTask;
+
+            public Task<DataTable> GetActiveAsync() =>
+                Task.FromResult(new DataTable());
+
+            public Task<DataTable> GetByPersonAsync(string personId) =>
+                Task.FromResult(new DataTable());
+
+            public Task<DataTable> GetAllAsync() =>
+                Task.FromResult(new DataTable());
+
+            public Task DeleteAsync(int id) => Task.CompletedTask;
         }
 
         private class StubPrinteryRepository : IPrinteryRepository

--- a/src/tests/Publishing.Core.Tests/OrderServiceTests.cs
+++ b/src/tests/Publishing.Core.Tests/OrderServiceTests.cs
@@ -14,6 +14,19 @@ namespace Publishing.Core.Tests
         {
             public Order? SavedOrder { get; private set; }
             public void Save(Order order) => SavedOrder = order;
+
+            public Task UpdateExpiredAsync() => Task.CompletedTask;
+
+            public Task<DataTable> GetActiveAsync() =>
+                Task.FromResult(new DataTable());
+
+            public Task<DataTable> GetByPersonAsync(string personId) =>
+                Task.FromResult(new DataTable());
+
+            public Task<DataTable> GetAllAsync() =>
+                Task.FromResult(new DataTable());
+
+            public Task DeleteAsync(int id) => Task.CompletedTask;
         }
 
         private class StubPrinteryRepository : IPrinteryRepository

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -9,7 +9,6 @@ using Publishing.Infrastructure;
 using BCrypt.Net;
 using Publishing.Core.Services;
 using Publishing.Infrastructure.Repositories;
-using Publishing.Infrastructure.DataAccess;
 
 namespace Publishing.Integration.Tests
 {
@@ -20,6 +19,8 @@ namespace Publishing.Integration.Tests
         private const string DbName = "PublishingCrud";
 
         private static string MasterConnection => $"Data Source={Server};Initial Catalog=master;Integrated Security=true";
+
+        private IDbContext _db = null!;
 
         [TestInitialize]
         public void Setup()


### PR DESCRIPTION
## Summary
- implement new async members in `StubOrderRepository` used in core tests
- switch integration test to `SqlDbContext` and add missing `IDbContext` field
- remove obsolete `Publishing.Infrastructure.DataAccess` using

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fdebf3948320bbaa346c214bbafa