### PR TITLE
Implement async order handling and fix tests

### DIFF
--- a/src/Publishing.Core/Interfaces/IOrderService.cs
+++ b/src/Publishing.Core/Interfaces/IOrderService.cs
@@ -1,10 +1,11 @@
 using Publishing.Core.Domain;
 using Publishing.Core.DTOs;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Interfaces
 {
     public interface IOrderService
     {
-        Order CreateOrder(CreateOrderDto dto);
+        Task<Order> CreateOrderAsync(CreateOrderDto dto);
     }
 }

--- a/src/Publishing.Core/Services/OrderService.cs
+++ b/src/Publishing.Core/Services/OrderService.cs
@@ -2,6 +2,7 @@ using System;
 using Publishing.Core.Domain;
 using Publishing.Core.DTOs;
 using Publishing.Core.Interfaces;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Services
 {
@@ -30,7 +31,7 @@ namespace Publishing.Core.Services
             _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
         }
 
-        public Order CreateOrder(CreateOrderDto dto)
+        public async Task<Order> CreateOrderAsync(CreateOrderDto dto)
         {
             if (dto is null)
                 throw new ArgumentNullException(nameof(dto));
@@ -53,7 +54,7 @@ namespace Publishing.Core.Services
                 Printery = dto.Printery
             };
 
-            SaveOrder(order);
+            await SaveOrderAsync(order).ConfigureAwait(false);
             return order;
         }
 
@@ -75,10 +76,13 @@ namespace Publishing.Core.Services
             return (start, finish);
         }
 
-        private void SaveOrder(Order order)
+        private Task SaveOrderAsync(Order order)
         {
-            _orderRepository.Save(order);
-            _logger.LogInformation($"Order for product {order.Name} saved.");
+            return Task.Run(() =>
+            {
+                _orderRepository.Save(order);
+                _logger.LogInformation($"Order for product {order.Name} saved.");
+            });
         }
     }
 }

--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -55,7 +55,7 @@ namespace Publishing
                 організаціяToolStripMenuItem.Visible = false;
         }
 
-        private void calculateButton_Click(object sender, EventArgs e)
+        private async void calculateButton_Click(object sender, EventArgs e)
         {
             if (!int.TryParse(pageNumTextBox.Text, out int pageNum))
             {
@@ -79,11 +79,11 @@ namespace Publishing
                 PersonId = CurrentUser.UserId
             };
 
-            var order = _orderService.CreateOrder(dto);
+            var order = await _orderService.CreateOrderAsync(dto).ConfigureAwait(false);
             totalPriceLabel.Text = "Кінцева ціна:" + order.Price.ToString();
         }
 
-        private void orderButton_Click(object sender, EventArgs e)
+        private async void orderButton_Click(object sender, EventArgs e)
         {
             string type = typeBox.SelectedItem?.ToString();
             if (type == null)
@@ -111,7 +111,7 @@ namespace Publishing
                 PersonId = CurrentUser.UserId
             };
 
-            var order = _orderService.CreateOrder(dto);
+            var order = await _orderService.CreateOrderAsync(dto).ConfigureAwait(false);
 
             MessageBox.Show("Замовлення успішно додано");
             totalPriceLabel.Text = "Кінцева ціна:" + order.Price.ToString();

--- a/src/tests/Publishing.Core.Tests/ExceptionFlowTests.cs
+++ b/src/tests/Publishing.Core.Tests/ExceptionFlowTests.cs
@@ -4,6 +4,8 @@ using Publishing.Core.Services;
 using Publishing.Core.DTOs;
 using Publishing.Core.Domain;
 using System;
+using System.Data;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Tests
 {
@@ -59,8 +61,7 @@ namespace Publishing.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void OrderService_ThrowsOnNullDto()
+        public async Task OrderService_ThrowsOnNullDto()
         {
             var service = new OrderService(
                 new StubOrderRepository(),
@@ -69,7 +70,8 @@ namespace Publishing.Core.Tests
                 new PriceCalculator(),
                 new StubValidator(),
                 new StubDateTimeProvider());
-            service.CreateOrder(null);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await service.CreateOrderAsync(null));
         }
     }
 }

--- a/src/tests/Publishing.Core.Tests/OrderServiceTests.cs
+++ b/src/tests/Publishing.Core.Tests/OrderServiceTests.cs
@@ -4,6 +4,8 @@ using Publishing.Core.Domain;
 using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using System;
+using System.Data;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Tests
 {
@@ -54,7 +56,7 @@ namespace Publishing.Core.Tests
         }
 
         [TestMethod]
-        public void CreateOrder_ReturnsFilledOrder()
+        public async Task CreateOrder_ReturnsFilledOrder()
         {
             var orderRepo = new StubOrderRepository();
             var printeryRepo = new StubPrinteryRepository();
@@ -67,7 +69,7 @@ namespace Publishing.Core.Tests
                 new StubDateTimeProvider());
             var dto = new CreateOrderDto { Type = "book", Name = "Intro", Pages = 10, Tirage = 3 };
 
-            var order = service.CreateOrder(dto);
+            var order = await service.CreateOrderAsync(dto);
 
             Assert.AreEqual(dto.Type, order.Type);
             Assert.AreEqual(dto.Name, order.Name);
@@ -80,35 +82,35 @@ namespace Publishing.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void CreateOrder_InvalidPages_Throws()
+        public async Task CreateOrder_InvalidPages_Throws()
         {
             var orderRepo = new StubOrderRepository();
             var printeryRepo = new StubPrinteryRepository();
             var service = new OrderService(orderRepo, printeryRepo, new StubLogger(), new PriceCalculator(), new PassThroughValidator(), new StubDateTimeProvider());
             var dto = new CreateOrderDto { Pages = -1, Tirage = 1 };
-            service.CreateOrder(dto);
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                await service.CreateOrderAsync(dto));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void CreateOrder_NullDto_Throws()
+        public async Task CreateOrder_NullDto_Throws()
         {
             var orderRepo = new StubOrderRepository();
             var printeryRepo = new StubPrinteryRepository();
             var service = new OrderService(orderRepo, printeryRepo, new StubLogger(), new PriceCalculator(), new PassThroughValidator(), new StubDateTimeProvider());
-            service.CreateOrder(null);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await service.CreateOrderAsync(null));
         }
 
         [TestMethod]
-        public void CreateOrder_RespectsCustomPricePerPage()
+        public async Task CreateOrder_RespectsCustomPricePerPage()
         {
             var orderRepo = new StubOrderRepository();
             var printeryRepo = new StubPrinteryRepository { PricePerPage = 3m };
             var service = new OrderService(orderRepo, printeryRepo, new StubLogger(), new PriceCalculator(), new PassThroughValidator(), new StubDateTimeProvider());
             var dto = new CreateOrderDto { Pages = 2, Tirage = 2 };
 
-            var order = service.CreateOrder(dto);
+            var order = await service.CreateOrderAsync(dto);
 
             Assert.AreEqual(12m, order.Price);
         }


### PR DESCRIPTION
## Summary
- enable async pattern in `IOrderService` and `OrderService`
- adapt UI form to use async order creation
- fix unit tests for async APIs
- add missing using directives in tests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff802da88320a355f4c3c0a75864