### PR TITLE
Fix Task usage in core interfaces

### DIFF
--- a/src/Publishing.Core/Interfaces/IAuthService.cs
+++ b/src/Publishing.Core/Interfaces/IAuthService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 namespace Publishing.Core.Interfaces
 {
     using Publishing.Core.DTOs;

--- a/src/Publishing.Core/Interfaces/ILoginRepository.cs
+++ b/src/Publishing.Core/Interfaces/ILoginRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Interfaces
 {


### PR DESCRIPTION
## Summary
- ensure System.Threading.Tasks is imported in authentication and login interfaces

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685427e656688320abd9fd9dc0b9a7f4