### PR TITLE
Fix Task namespace usage

### DIFF
--- a/src/Publishing.Core/Interfaces/IAuthService.cs
+++ b/src/Publishing.Core/Interfaces/IAuthService.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
+using Publishing.Core.DTOs;
+
 namespace Publishing.Core.Interfaces
 {
-    using Publishing.Core.DTOs;
 
     public interface IAuthService
     {

--- a/src/Publishing.Core/Interfaces/ILoginRepository.cs
+++ b/src/Publishing.Core/Interfaces/ILoginRepository.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Publishing.Core.Interfaces
 {

--- a/src/Publishing.Core/Services/AuthService.cs
+++ b/src/Publishing.Core/Services/AuthService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using System;
 using BCrypt.Net;
 using Publishing.Core.DTOs;

--- a/src/Publishing.Infrastructure/Repositories/LoginRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/LoginRepository.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using Dapper;


### PR DESCRIPTION
## Summary
- fix missing `Task` namespace in `AuthService`
- fix missing `Task` namespace in `LoginRepository`
- organize `Task` usings in core interfaces

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542928ff3483209905dc43a1be9538