### PR TITLE
Fix SQL client SNI package

### DIFF
--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -20,8 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient.SNI.x64" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient.SNI.x86" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json">


### PR DESCRIPTION
## Summary
- use the combined Microsoft.Data.SqlClient.SNI.runtime package for SQL Server

## Testing
- `dotnet restore Publishing.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685431468a548320ae3bf9da9ecae747