### PR TITLE
Add global exception dialog

### DIFF
--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -21,8 +21,14 @@ namespace Publishing
         [STAThread]
         static void Main()
         {
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            // Global handlers for unhandled exceptions
+            Application.ThreadException += (s, e) => ShowGlobalException(e.Exception);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                ShowGlobalException(e.ExceptionObject as Exception);
 
             var services = new ServiceCollection();
             ConfigureServices(services);
@@ -67,6 +73,19 @@ namespace Publishing
             services.AddTransient<profileForm>();
             services.AddTransient<organizationForm>();
             services.AddTransient<statisticForm>();
+        }
+
+        private static void ShowGlobalException(Exception? ex)
+        {
+            if (ex == null) return;
+            // MessageBoxOptions.ServiceNotification shows the dialog above all windows
+            MessageBox.Show(
+                ex.ToString(),
+                "Unhandled Exception",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error,
+                MessageBoxDefaultButton.Button1,
+                MessageBoxOptions.ServiceNotification);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add system-aware DPI mode
- add global unhandled exception handlers for WinForms app

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854325ec9f08320b1d3ee6b6cd8c04d