### PR TITLE
Fix connection string and DI

### DIFF
--- a/src/Publishing.Infrastructure/SqlDbContext.cs
+++ b/src/Publishing.Infrastructure/SqlDbContext.cs
@@ -4,26 +4,29 @@ namespace Publishing.Infrastructure
     using System.Threading.Tasks;
     using Dapper;
     using Microsoft.Data.SqlClient;
+    using Microsoft.Extensions.Configuration;
     using Publishing.Core.Interfaces;
 
     public class SqlDbContext : IDbContext
     {
         private readonly string _connectionString;
 
-        public SqlDbContext(string connectionString)
+        public SqlDbContext(IConfiguration config)
         {
-            _connectionString = connectionString;
+            _connectionString = config.GetConnectionString("DefaultConnection")!;
         }
 
         public async Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null)
         {
             await using var con = new SqlConnection(_connectionString);
+            await con.OpenAsync();
             return await con.QueryAsync<T>(sql, param);
         }
 
         public async Task<int> ExecuteAsync(string sql, object? param = null)
         {
             await using var con = new SqlConnection(_connectionString);
+            await con.OpenAsync();
             return await con.ExecuteAsync(sql, param);
         }
     }

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -56,11 +56,14 @@ namespace Publishing
             services.AddScoped<IPriceCalculator, PriceCalculator>();
             services.AddScoped<IOrderValidator, OrderValidator>();
             services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
-            IConfiguration config = new ConfigurationBuilder()
+
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
-            string cs = config.GetConnectionString("Publishing")!;
-            services.AddScoped<IDbContext>(sp => new SqlDbContext(cs));
+
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddScoped<IDbContext, SqlDbContext>();
             services.AddScoped<ILoginRepository, LoginRepository>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<INavigationService, NavigationService>();

--- a/src/Publishing.UI/appsettings.json
+++ b/src/Publishing.UI/appsettings.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "Publishing": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=Publishing;Trusted_Connection=True;"
   }
 }

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
 using System.Linq;
 using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
@@ -41,7 +42,13 @@ CREATE DATABASE [{DbName}];";
             }
 
             var cs = $"Data Source={Server};Initial Catalog={DbName};Integrated Security=true";
-            _db = new SqlDbContext(cs);
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = cs
+                })
+                .Build();
+            _db = new SqlDbContext(config);
 
             // create minimal schema
             _db.ExecuteAsync(

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using System.Linq;
 using Publishing.Core.Interfaces;
@@ -38,7 +39,13 @@ CREATE DATABASE [{DbName}];";
             }
 
             var cs = $"Data Source={Server};Initial Catalog={DbName};Integrated Security=true";
-            _db = new SqlDbContext(cs);
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = cs
+                })
+                .Build();
+            _db = new SqlDbContext(config);
         }
 
         [TestCleanup]

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
 using System.Linq;
 using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
@@ -36,7 +37,13 @@ CREATE DATABASE [{DbName}];";
             }
 
             var cs = $"Data Source={Server};Initial Catalog={DbName};Integrated Security=true";
-            _db = new SqlDbContext(cs);
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = cs
+                })
+                .Build();
+            _db = new SqlDbContext(config);
 
             _db.ExecuteAsync("CREATE TABLE Person(idPerson INT IDENTITY(1,1) PRIMARY KEY, FName NVARCHAR(50));").Wait();
             _db.ExecuteAsync("CREATE TABLE Orders(idOrder INT IDENTITY(1,1) PRIMARY KEY, idPerson INT, dateOrder DATETIME);").Wait();


### PR DESCRIPTION
## Summary
- point connection string to localdb
- load configuration via DI
- read connection string inside `SqlDbContext`
- update integration tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685433752e008320a5c8847abaeb548c