### PR TITLE
Fix missing IConfiguration reference

### DIFF
--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -14,6 +14,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
+    <!-- Нам потрібне IConfiguration для SqlDbContext -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- reference Microsoft.Extensions.Configuration.Abstractions in Publishing.Infrastructure

## Testing
- `dotnet restore Publishing.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685436c6435083208eed3a5f517720fa