### PR TITLE
Align EF Core packages with net6 target

### DIFF
--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -16,10 +16,11 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <!-- Нам потрібне IConfiguration для SqlDbContext -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.21">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json">

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Publishing.Infrastructure\Publishing.Infrastructure.csproj" />


### PR DESCRIPTION
## Summary
- downgrade EF Core dependencies to 6.0.21 so that projects targeting net6 run without NU1202

## Testing
- `dotnet restore src/Publishing.Infrastructure/Publishing.Infrastructure.csproj` *(fails: dotnet not found)*
- `dotnet restore src/Publishing.UI/Publishing.UI.csproj` *(fails: dotnet not found)*
- `dotnet restore src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj` *(fails: dotnet not found)*
- `dotnet build src/Publishing.Infrastructure/Publishing.Infrastructure.csproj` *(fails: dotnet not found)*


------
https://chatgpt.com/codex/tasks/task_e_68543cea6f348320a18e7da0bb6f7373