### PR TITLE
Add database initializer service

### DIFF
--- a/src/Publishing.Infrastructure/DatabaseInitializer.cs
+++ b/src/Publishing.Infrastructure/DatabaseInitializer.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Publishing.Infrastructure
+{
+    public class DatabaseInitializer : IDatabaseInitializer
+    {
+        private readonly Migrations.PublishingDbContext _ctx;
+        private readonly ILogger<DatabaseInitializer> _log;
+
+        public DatabaseInitializer(Migrations.PublishingDbContext ctx, ILogger<DatabaseInitializer> log)
+        {
+            _ctx = ctx;
+            _log = log;
+        }
+
+        public void Initialize()
+        {
+            _log.LogInformation("Applying EF Core migrations...");
+            _ctx.Database.Migrate();
+            _log.LogInformation("Database schema is up to date.");
+        }
+    }
+}

--- a/src/Publishing.Infrastructure/IDatabaseInitializer.cs
+++ b/src/Publishing.Infrastructure/IDatabaseInitializer.cs
@@ -1,0 +1,7 @@
+namespace Publishing.Infrastructure
+{
+    public interface IDatabaseInitializer
+    {
+        void Initialize();
+    }
+}

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -35,11 +35,11 @@ namespace Publishing
             ConfigureServices(services);
             Services = services.BuildServiceProvider();
 
-            // apply pending migrations
             using (var scope = Services.CreateScope())
             {
-                var ctx = scope.ServiceProvider.GetRequiredService<Publishing.Infrastructure.Migrations.PublishingDbContext>();
-                ctx.Database.Migrate();
+                scope.ServiceProvider
+                    .GetRequiredService<IDatabaseInitializer>()
+                    .Initialize();
             }
 
             var form = Services.GetRequiredService<loginForm>();
@@ -73,6 +73,7 @@ namespace Publishing
             services.AddSingleton<IConfiguration>(configuration);
             services.AddDbContext<Publishing.Infrastructure.Migrations.PublishingDbContext>(
                 options => options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+            services.AddScoped<IDatabaseInitializer, DatabaseInitializer>();
             services.AddScoped<IDbContext, SqlDbContext>();
             services.AddScoped<ILoginRepository, LoginRepository>();
             services.AddScoped<IAuthService, AuthService>();


### PR DESCRIPTION
## Summary
- add interface `IDatabaseInitializer` in infrastructure
- implement `DatabaseInitializer` that applies EF Core migrations
- resolve initializer in Program.Main using a scope

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543f8830188320aa847bd29f0efacb