### PR TITLE
Implement EF Core migrations infrastructure

### DIFF
--- a/src/Publishing.Core/Interfaces/IDatabaseInitializer.cs
+++ b/src/Publishing.Core/Interfaces/IDatabaseInitializer.cs
@@ -1,0 +1,7 @@
+namespace Publishing.Core.Interfaces
+{
+    public interface IDatabaseInitializer
+    {
+        void Initialize();
+    }
+}

--- a/src/Publishing.Infrastructure/DatabaseMigrator.cs
+++ b/src/Publishing.Infrastructure/DatabaseMigrator.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Publishing.Core.Interfaces;
+using Publishing.Migrations;
+
+namespace Publishing.Infrastructure
+{
+    public class DatabaseMigrator : IDatabaseInitializer
+    {
+        private readonly IConfiguration _config;
+
+        public DatabaseMigrator(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlServer(_config.GetConnectionString("DefaultConnection"))
+                .Options;
+
+            using var context = new AppDbContext(options);
+            context.Database.Migrate();
+        }
+    }
+}

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <Folder Include="DI\" />
     <Folder Include="Repositories\" />
     <ProjectReference Include="..\Publishing.Core\Publishing.Core.csproj" />
+    <ProjectReference Include="..\Publishing.Migrations\Publishing.Migrations.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/src/Publishing.Migrations/AppDbContext.cs
+++ b/src/Publishing.Migrations/AppDbContext.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using Publishing.Migrations.Entities;
+
+namespace Publishing.Migrations
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Person> Persons => Set<Person>();
+        public DbSet<Pass> Passes => Set<Pass>();
+        public DbSet<Product> Products => Set<Product>();
+        public DbSet<Order> Orders => Set<Order>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Person>(entity =>
+            {
+                entity.ToTable("Person");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).HasColumnName("idPerson");
+                entity.Property(e => e.FName).HasColumnName("FName");
+                entity.Property(e => e.LName).HasColumnName("LName");
+                entity.Property(e => e.Email).HasColumnName("emailPerson");
+                entity.Property(e => e.Type).HasColumnName("typePerson");
+                entity.Property(e => e.Phone).HasColumnName("phonePerson");
+                entity.Property(e => e.Fax).HasColumnName("faxPerson");
+                entity.Property(e => e.Address).HasColumnName("addressPerson");
+            });
+
+            modelBuilder.Entity<Pass>(entity =>
+            {
+                entity.ToTable("Pass");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).HasColumnName("id");
+                entity.Property(e => e.Password).HasColumnName("password");
+                entity.Property(e => e.PersonId).HasColumnName("idPerson");
+                entity.HasOne(e => e.Person)
+                      .WithOne(p => p.Pass!)
+                      .HasForeignKey<Pass>(e => e.PersonId);
+            });
+
+            modelBuilder.Entity<Product>(entity =>
+            {
+                entity.ToTable("Product");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).HasColumnName("idProduct");
+                entity.Property(e => e.PersonId).HasColumnName("idPerson");
+                entity.Property(e => e.Type).HasColumnName("typeProduct");
+                entity.Property(e => e.Name).HasColumnName("nameProduct");
+                entity.Property(e => e.Pages).HasColumnName("pagesNum");
+                entity.HasOne(e => e.Person)
+                      .WithMany(p => p.Products)
+                      .HasForeignKey(e => e.PersonId);
+            });
+
+            modelBuilder.Entity<Order>(entity =>
+            {
+                entity.ToTable("Orders");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).HasColumnName("idOrder");
+                entity.Property(e => e.ProductId).HasColumnName("idProduct");
+                entity.Property(e => e.PersonId).HasColumnName("idPerson");
+                entity.Property(e => e.NamePrintery).HasColumnName("namePrintery");
+                entity.Property(e => e.DateOrder).HasColumnName("dateOrder");
+                entity.Property(e => e.DateStart).HasColumnName("dateStart");
+                entity.Property(e => e.DateFinish).HasColumnName("dateFinish");
+                entity.Property(e => e.Status).HasColumnName("statusOrder");
+                entity.Property(e => e.Tirage).HasColumnName("tirage");
+                entity.Property(e => e.Price).HasColumnName("price");
+                entity.HasOne(e => e.Product)
+                      .WithMany(p => p.Orders)
+                      .HasForeignKey(e => e.ProductId);
+                entity.HasOne(e => e.Person)
+                      .WithMany(p => p.Orders)
+                      .HasForeignKey(e => e.PersonId);
+            });
+        }
+    }
+}

--- a/src/Publishing.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Publishing.Migrations/DesignTimeDbContextFactory.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace Publishing.Migrations
+{
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+    {
+        public AppDbContext CreateDbContext(string[] args)
+        {
+            IConfiguration config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+            var cs = config.GetConnectionString("DefaultConnection") ?? string.Empty;
+            optionsBuilder.UseSqlServer(cs);
+            return new AppDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/src/Publishing.Migrations/Entities/Order.cs
+++ b/src/Publishing.Migrations/Entities/Order.cs
@@ -1,0 +1,19 @@
+namespace Publishing.Migrations.Entities
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public int ProductId { get; set; }
+        public int PersonId { get; set; }
+        public string NamePrintery { get; set; } = string.Empty;
+        public DateTime DateOrder { get; set; }
+        public DateTime DateStart { get; set; }
+        public DateTime DateFinish { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public int Tirage { get; set; }
+        public int Price { get; set; }
+
+        public Person Person { get; set; } = null!;
+        public Product Product { get; set; } = null!;
+    }
+}

--- a/src/Publishing.Migrations/Entities/Pass.cs
+++ b/src/Publishing.Migrations/Entities/Pass.cs
@@ -1,0 +1,10 @@
+namespace Publishing.Migrations.Entities
+{
+    public class Pass
+    {
+        public int Id { get; set; }
+        public string Password { get; set; } = string.Empty;
+        public int PersonId { get; set; }
+        public Person Person { get; set; } = null!;
+    }
+}

--- a/src/Publishing.Migrations/Entities/Person.cs
+++ b/src/Publishing.Migrations/Entities/Person.cs
@@ -1,0 +1,18 @@
+namespace Publishing.Migrations.Entities
+{
+    public class Person
+    {
+        public int Id { get; set; }
+        public string FName { get; set; } = string.Empty;
+        public string LName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string? Phone { get; set; }
+        public string? Fax { get; set; }
+        public string? Address { get; set; }
+
+        public ICollection<Product> Products { get; set; } = new List<Product>();
+        public ICollection<Order> Orders { get; set; } = new List<Order>();
+        public Pass? Pass { get; set; }
+    }
+}

--- a/src/Publishing.Migrations/Entities/Product.cs
+++ b/src/Publishing.Migrations/Entities/Product.cs
@@ -1,0 +1,14 @@
+namespace Publishing.Migrations.Entities
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public int PersonId { get; set; }
+        public string Type { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public int Pages { get; set; }
+
+        public Person Person { get; set; } = null!;
+        public ICollection<Order> Orders { get; set; } = new List<Order>();
+    }
+}

--- a/src/Publishing.Migrations/Migrations/InitialCreate.cs
+++ b/src/Publishing.Migrations/Migrations/InitialCreate.cs
@@ -1,0 +1,141 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Publishing.Migrations.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Person",
+                columns: table => new
+                {
+                    idPerson = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FName = table.Column<string>(nullable: false),
+                    LName = table.Column<string>(nullable: false),
+                    emailPerson = table.Column<string>(nullable: false),
+                    typePerson = table.Column<string>(nullable: false),
+                    phonePerson = table.Column<string>(nullable: true),
+                    faxPerson = table.Column<string>(nullable: true),
+                    addressPerson = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Person", x => x.idPerson);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Pass",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    password = table.Column<string>(nullable: false),
+                    idPerson = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Pass", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_Pass_Person_idPerson",
+                        column: x => x.idPerson,
+                        principalTable: "Person",
+                        principalColumn: "idPerson",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Product",
+                columns: table => new
+                {
+                    idProduct = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    idPerson = table.Column<int>(nullable: false),
+                    typeProduct = table.Column<string>(nullable: false),
+                    nameProduct = table.Column<string>(nullable: false),
+                    pagesNum = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Product", x => x.idProduct);
+                    table.ForeignKey(
+                        name: "FK_Product_Person_idPerson",
+                        column: x => x.idPerson,
+                        principalTable: "Person",
+                        principalColumn: "idPerson",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    idOrder = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    idProduct = table.Column<int>(nullable: false),
+                    idPerson = table.Column<int>(nullable: false),
+                    namePrintery = table.Column<string>(nullable: false),
+                    dateOrder = table.Column<DateTime>(nullable: false),
+                    dateStart = table.Column<DateTime>(nullable: false),
+                    dateFinish = table.Column<DateTime>(nullable: false),
+                    statusOrder = table.Column<string>(nullable: false),
+                    tirage = table.Column<int>(nullable: false),
+                    price = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.idOrder);
+                    table.ForeignKey(
+                        name: "FK_Orders_Person_idPerson",
+                        column: x => x.idPerson,
+                        principalTable: "Person",
+                        principalColumn: "idPerson",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Orders_Product_idProduct",
+                        column: x => x.idProduct,
+                        principalTable: "Product",
+                        principalColumn: "idProduct",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Pass_idPerson",
+                table: "Pass",
+                column: "idPerson",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Product_idPerson",
+                table: "Product",
+                column: "idPerson");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_idPerson",
+                table: "Orders",
+                column: "idPerson");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_idProduct",
+                table: "Orders",
+                column: "idProduct");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Orders");
+
+            migrationBuilder.DropTable(
+                name: "Pass");
+
+            migrationBuilder.DropTable(
+                name: "Product");
+
+            migrationBuilder.DropTable(
+                name: "Person");
+        }
+    }
+}

--- a/src/Publishing.Migrations/Publishing.Migrations.csproj
+++ b/src/Publishing.Migrations/Publishing.Migrations.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Publishing.Migrations/appsettings.json
+++ b/src/Publishing.Migrations/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=Publishing;Trusted_Connection=True;"
+  }
+}

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -28,6 +28,9 @@ namespace Publishing
             ConfigureServices(services);
             Services = services.BuildServiceProvider();
 
+            var migrator = Services.GetRequiredService<IDatabaseInitializer>();
+            migrator.Initialize();
+
             var form = Services.GetRequiredService<loginForm>();
             Application.Run(form);
 
@@ -62,6 +65,7 @@ namespace Publishing
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<INavigationService, NavigationService>();
             services.AddScoped<IOrderService, OrderService>();
+            services.AddScoped<IDatabaseInitializer, DatabaseMigrator>();
             services.AddTransient<loginForm>();
             services.AddTransient<registrationForm>();
             services.AddTransient<addOrderForm>();


### PR DESCRIPTION
## Summary
- add database initializer interface
- implement DatabaseMigrator using EF Core
- create new Publishing.Migrations project with DbContext and initial migration
- register and run DatabaseMigrator from Program
- reference migrations project from infrastructure

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68544a2463888320a88ffa31f04bb711