### PR TITLE
Implement connection factory and helper

### DIFF
--- a/src/Publishing.Core/Interfaces/IDbConnectionFactory.cs
+++ b/src/Publishing.Core/Interfaces/IDbConnectionFactory.cs
@@ -1,0 +1,10 @@
+namespace Publishing.Core.Interfaces
+{
+    using System.Data;
+    using System.Threading.Tasks;
+
+    public interface IDbConnectionFactory
+    {
+        Task<IDbConnection> CreateOpenConnectionAsync();
+    }
+}

--- a/src/Publishing.Core/Interfaces/IDbHelper.cs
+++ b/src/Publishing.Core/Interfaces/IDbHelper.cs
@@ -1,0 +1,12 @@
+namespace Publishing.Core.Interfaces
+{
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Threading.Tasks;
+
+    public interface IDbHelper
+    {
+        Task<DataTable> QueryDataTableAsync(string sql, object? param = null);
+        Task<List<string[]>> QueryStringListAsync(string sql, object? param = null);
+    }
+}

--- a/src/Publishing.Core/Interfaces/IRepository.cs
+++ b/src/Publishing.Core/Interfaces/IRepository.cs
@@ -1,0 +1,11 @@
+namespace Publishing.Core.Interfaces
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public interface IRepository<T>
+    {
+        Task<IEnumerable<T>> QueryAsync(string sql, object? param = null);
+        Task<int> ExecuteAsync(string sql, object? param = null);
+    }
+}

--- a/src/Publishing.Infrastructure/DapperRepository.cs
+++ b/src/Publishing.Infrastructure/DapperRepository.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Publishing.Core.Interfaces;
+
+namespace Publishing.Infrastructure
+{
+    public abstract class DapperRepository<T> : IRepository<T>
+    {
+        protected readonly IDbContext Db;
+
+        protected DapperRepository(IDbContext db)
+        {
+            Db = db;
+        }
+
+        public Task<IEnumerable<T>> QueryAsync(string sql, object? param = null)
+            => Db.QueryAsync<T>(sql, param);
+
+        public Task<int> ExecuteAsync(string sql, object? param = null)
+            => Db.ExecuteAsync(sql, param);
+    }
+}

--- a/src/Publishing.Infrastructure/DbHelper.cs
+++ b/src/Publishing.Infrastructure/DbHelper.cs
@@ -1,17 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Publishing.Core.Interfaces;
+
 namespace Publishing.Infrastructure
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Threading.Tasks;
-    using Dapper;
-    using Publishing.Core.Interfaces;
-
-    public static class DbContextExtensions
+    public class DbHelper : IDbHelper
     {
-        public static async Task<DataTable> QueryDataTableAsync(this IDbContext db, string sql, object? param = null)
+        private readonly IDbContext _db;
+
+        public DbHelper(IDbContext db)
         {
-            var result = await db.QueryAsync<dynamic>(sql, param);
+            _db = db;
+        }
+
+        public async Task<DataTable> QueryDataTableAsync(string sql, object? param = null)
+        {
+            var result = await _db.QueryAsync<dynamic>(sql, param);
             var table = new DataTable();
             bool columnsCreated = false;
             foreach (var row in result)
@@ -35,9 +41,9 @@ namespace Publishing.Infrastructure
             return table;
         }
 
-        public static async Task<List<string[]>> QueryStringListAsync(this IDbContext db, string sql, object? param = null)
+        public async Task<List<string[]>> QueryStringListAsync(string sql, object? param = null)
         {
-            var result = await db.QueryAsync<dynamic>(sql, param);
+            var result = await _db.QueryAsync<dynamic>(sql, param);
             var list = new List<string[]>();
             foreach (var row in result)
             {

--- a/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
@@ -8,10 +8,12 @@ namespace Publishing.Infrastructure.Repositories
     public class OrderRepository : IOrderRepository
     {
         private readonly IDbContext _db;
+        private readonly IDbHelper _helper;
 
-        public OrderRepository(IDbContext db)
+        public OrderRepository(IDbContext db, IDbHelper helper)
         {
             _db = db;
+            _helper = helper;
         }
 
         public void Save(Publishing.Core.Domain.Order order)
@@ -62,18 +64,18 @@ namespace Publishing.Infrastructure.Repositories
         public Task<DataTable> GetActiveAsync()
         {
             const string sql = @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price FROM(Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct ) INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder = 'в роботі' ORDER BY O.dateOrder";
-            return DbContextExtensions.QueryDataTableAsync(_db, sql);
+            return _helper.QueryDataTableAsync(sql);
         }
 
         public Task<DataTable> GetByPersonAsync(string personId)
         {
             const string sql = "SELECT * FROM Orders where idPerson = @id";
-            return DbContextExtensions.QueryDataTableAsync(_db, sql, new { id = personId });
+            return _helper.QueryDataTableAsync(sql, new { id = personId });
         }
 
         public Task<DataTable> GetAllAsync()
         {
-            return DbContextExtensions.QueryDataTableAsync(_db, "SELECT * FROM Orders");
+            return _helper.QueryDataTableAsync("SELECT * FROM Orders");
         }
 
         public Task DeleteAsync(int id)

--- a/src/Publishing.Infrastructure/Repositories/StatisticRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/StatisticRepository.cs
@@ -7,47 +7,47 @@ namespace Publishing.Infrastructure.Repositories
 {
     public class StatisticRepository : IStatisticRepository
     {
-        private readonly IDbContext _db;
+        private readonly IDbHelper _helper;
 
-        public StatisticRepository(IDbContext db)
+        public StatisticRepository(IDbHelper helper)
         {
-            _db = db;
+            _helper = helper;
         }
 
         public Task<List<string[]>> GetAuthorNamesAsync()
         {
             const string sql = "SELECT DISTINCT (FName + ' ' + LName) AS Author FROM Person P INNER JOIN Orders O ON O.idPerson = P.idPerson";
-            return DbContextExtensions.QueryStringListAsync(_db, sql);
+            return _helper.QueryStringListAsync(sql);
         }
 
         public Task<List<string[]>> GetOrdersPerMonthAsync()
         {
             const string sql = "SELECT DATENAME(MONTH, dateOrder) AS orderMonth, COUNT(*) AS Number FROM Orders WHERE YEAR(dateOrder) = YEAR(GETDATE()) GROUP BY DATENAME(MONTH, dateOrder)";
-            return DbContextExtensions.QueryStringListAsync(_db, sql);
+            return _helper.QueryStringListAsync(sql);
         }
 
         public Task<List<string[]>> GetOrdersPerAuthorAsync()
         {
             const string sql = "SELECT (P.FName + ' ' + P.LName) AS Author, COUNT(*) AS Number FROM Orders O INNER JOIN Person P ON P.idPerson = O.idPerson GROUP BY (P.FName + ' ' + P.LName)";
-            return DbContextExtensions.QueryStringListAsync(_db, sql);
+            return _helper.QueryStringListAsync(sql);
         }
 
         public Task<List<string[]>> GetOrdersPerAuthorAsync(string fullName)
         {
             const string sql = "SELECT (P.FName + ' ' + P.LName) AS Author, COUNT(*) AS Number FROM Orders O INNER JOIN Person P ON P.idPerson = O.idPerson WHERE (P.FName + ' ' + P.LName) = @fullNameAuthor GROUP BY (P.FName + ' ' + P.LName)";
-            return DbContextExtensions.QueryStringListAsync(_db, sql, new { fullNameAuthor = fullName });
+            return _helper.QueryStringListAsync(sql, new { fullNameAuthor = fullName });
         }
 
         public Task<List<string[]>> GetOrdersPerMonthAsync(DateTime start, DateTime end)
         {
             const string sql = "SELECT DATENAME(MONTH, dateOrder) AS orderMonth, COUNT(*) AS Number FROM Orders O INNER JOIN Person P ON P.idPerson = O.idPerson WHERE dateOrder BETWEEN @StartDate AND @EndDate GROUP BY DATENAME(MONTH, dateOrder)";
-            return DbContextExtensions.QueryStringListAsync(_db, sql, new { StartDate = start, EndDate = end });
+            return _helper.QueryStringListAsync(sql, new { StartDate = start, EndDate = end });
         }
 
         public Task<List<string[]>> GetTiragePerAuthorAsync()
         {
             const string sql = "SELECT (P.FName + ' ' + P.LName) AS Author, Sum(tirage) AS sumTirage FROM Orders O INNER JOIN Person P ON P.idPerson = O.idPerson GROUP BY (P.FName + ' ' + P.LName)";
-            return DbContextExtensions.QueryStringListAsync(_db, sql);
+            return _helper.QueryStringListAsync(sql);
         }
     }
 }

--- a/src/Publishing.Infrastructure/SqlDbConnectionFactory.cs
+++ b/src/Publishing.Infrastructure/SqlDbConnectionFactory.cs
@@ -1,0 +1,24 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using Publishing.Core.Interfaces;
+
+namespace Publishing.Infrastructure
+{
+    public class SqlDbConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public SqlDbConnectionFactory(IConfiguration configuration)
+        {
+            _connectionString = configuration.GetConnectionString("DefaultConnection")!;
+        }
+
+        public async Task<IDbConnection> CreateOpenConnectionAsync()
+        {
+            var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+            return connection;
+        }
+    }
+}

--- a/src/Publishing.Infrastructure/SqlDbContext.cs
+++ b/src/Publishing.Infrastructure/SqlDbContext.cs
@@ -3,30 +3,26 @@ namespace Publishing.Infrastructure
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Dapper;
-    using Microsoft.Data.SqlClient;
-    using Microsoft.Extensions.Configuration;
     using Publishing.Core.Interfaces;
 
     public class SqlDbContext : IDbContext
     {
-        private readonly string _connectionString;
+        private readonly IDbConnectionFactory _connectionFactory;
 
-        public SqlDbContext(IConfiguration config)
+        public SqlDbContext(IDbConnectionFactory connectionFactory)
         {
-            _connectionString = config.GetConnectionString("DefaultConnection")!;
+            _connectionFactory = connectionFactory;
         }
 
         public async Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null)
         {
-            await using var con = new SqlConnection(_connectionString);
-            await con.OpenAsync();
+            await using var con = await _connectionFactory.CreateOpenConnectionAsync();
             return await con.QueryAsync<T>(sql, param);
         }
 
         public async Task<int> ExecuteAsync(string sql, object? param = null)
         {
-            await using var con = new SqlConnection(_connectionString);
-            await con.OpenAsync();
+            await using var con = await _connectionFactory.CreateOpenConnectionAsync();
             return await con.ExecuteAsync(sql, param);
         }
     }

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -60,7 +60,9 @@ namespace Publishing
                 .Build();
 
             services.AddSingleton<IConfiguration>(configuration);
+            services.AddSingleton<IDbConnectionFactory, SqlDbConnectionFactory>();
             services.AddScoped<IDbContext, SqlDbContext>();
+            services.AddScoped<IDbHelper, DbHelper>();
             services.AddScoped<ILoginRepository, LoginRepository>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<INavigationService, NavigationService>();

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -47,7 +47,8 @@ CREATE DATABASE [{DbName}];";
                     ["ConnectionStrings:DefaultConnection"] = cs
                 })
                 .Build();
-            _db = new SqlDbContext(config);
+            var factory = new SqlDbConnectionFactory(config);
+            _db = new SqlDbContext(factory);
 
             // create minimal schema
             _db.ExecuteAsync(

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -20,6 +20,7 @@ namespace Publishing.Integration.Tests
         private static string MasterConnection => $"Data Source={Server};Initial Catalog=master;Integrated Security=true";
 
         private IDbContext _db = null!;
+        private IDbHelper _helper = null!;
 
         [TestInitialize]
         public void Setup()
@@ -45,7 +46,9 @@ CREATE DATABASE [{DbName}];";
                     ["ConnectionStrings:DefaultConnection"] = cs
                 })
                 .Build();
-            _db = new SqlDbContext(config);
+            var factory = new SqlDbConnectionFactory(config);
+            _db = new SqlDbContext(factory);
+            _helper = new DbHelper(_db);
         }
 
         [TestCleanup]
@@ -88,7 +91,7 @@ END";
         {
             _db.ExecuteAsync("CREATE TABLE Sample(id INT, name NVARCHAR(30))").Wait();
             _db.ExecuteAsync("INSERT INTO Sample(id,name) VALUES(1,'a'),(2,'b')").Wait();
-            DataTable dt = DbContextExtensions.QueryDataTableAsync(_db, "SELECT * FROM Sample").Result;
+            DataTable dt = _helper.QueryDataTableAsync("SELECT * FROM Sample").Result;
             Assert.AreEqual(2, dt.Rows.Count);
             Assert.AreEqual("name", dt.Columns[1].ColumnName);
         }
@@ -98,7 +101,7 @@ END";
         {
             _db.ExecuteAsync("CREATE TABLE Filter(id INT, name NVARCHAR(30))").Wait();
             _db.ExecuteAsync("INSERT INTO Filter(id,name) VALUES(1,'x'),(2,'y')").Wait();
-            DataTable dt = DbContextExtensions.QueryDataTableAsync(_db, "SELECT name FROM Filter WHERE id = @id", new { id = 2 }).Result;
+            DataTable dt = _helper.QueryDataTableAsync("SELECT name FROM Filter WHERE id = @id", new { id = 2 }).Result;
             Assert.AreEqual(1, dt.Rows.Count);
             Assert.AreEqual("y", dt.Rows[0][0]);
         }
@@ -108,7 +111,7 @@ END";
         {
             _db.ExecuteAsync("CREATE TABLE Lst(id INT, name NVARCHAR(30))").Wait();
             _db.ExecuteAsync("INSERT INTO Lst(id,name) VALUES(1,'one'),(2,'two')").Wait();
-            var list = DbContextExtensions.QueryStringListAsync(_db, "SELECT name FROM Lst ORDER BY id").Result;
+            var list = _helper.QueryStringListAsync("SELECT name FROM Lst ORDER BY id").Result;
             Assert.AreEqual(2, list.Count);
             CollectionAssert.AreEqual(new[] { "one", "two" }, new[] { list[0][0], list[1][0] });
         }


### PR DESCRIPTION
## Summary
- centralize opening DB connections via `IDbConnectionFactory` and `SqlDbConnectionFactory`
- replace static DB helpers with `IDbHelper`/`DbHelper`
- refactor `SqlDbContext` and repositories to use these abstractions
- register new services in DI setup
- update integration tests for new APIs

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68544cb2134083208b69e753ecc99dd6