### PR TITLE
Add localization resources and formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+dotnet_sort_system_directives_first = true
+charset = utf-8

--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -3,6 +3,7 @@ using Publishing.Core.DTOs;
 using Publishing.Core.Interfaces;
 using System.Windows.Forms;
 using Publishing.Services;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -10,16 +11,18 @@ namespace Publishing
     {
         private readonly IOrderService _orderService;
         private readonly INavigationService _navigation;
+        private readonly IStringLocalizer<SharedResource> _localizer;
         [Obsolete("Designer only", error: false)]
         public addOrderForm()
         {
             InitializeComponent();
         }
 
-        public addOrderForm(IOrderService orderService, INavigationService navigation)
+        public addOrderForm(IOrderService orderService, INavigationService navigation, IStringLocalizer<SharedResource> localizer)
         {
             _orderService = orderService;
             _navigation = navigation;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -59,13 +62,13 @@ namespace Publishing
         {
             if (!int.TryParse(pageNumTextBox.Text, out int pageNum))
             {
-                MessageBox.Show("pagesNumParse");
+                MessageBox.Show(_localizer["PagesNumParse"]);
                 return;
             }
 
             if (!int.TryParse(tirageTextBox.Text, out int tirageNum))
             {
-                MessageBox.Show("tirageParse");
+                MessageBox.Show(_localizer["TirageParse"]);
                 return;
             }
 
@@ -91,13 +94,13 @@ namespace Publishing
 
             if (!int.TryParse(pageNumTextBox.Text, out int pageNum))
             {
-                MessageBox.Show("pagesNumParse");
+                MessageBox.Show(_localizer["PagesNumParse"]);
                 return;
             }
 
             if (!int.TryParse(tirageTextBox.Text, out int tirageNum))
             {
-                MessageBox.Show("tirageParse");
+                MessageBox.Show(_localizer["TirageParse"]);
                 return;
             }
 
@@ -113,7 +116,7 @@ namespace Publishing
 
             var order = await _orderService.CreateOrderAsync(dto).ConfigureAwait(false);
 
-            MessageBox.Show("Замовлення успішно додано");
+            MessageBox.Show(_localizer["OrderAdded"]);
             totalPriceLabel.Text = "Кінцева ціна:" + order.Price.ToString();
 
             _navigation.Navigate<mainForm>(this);

--- a/src/Publishing.UI/Forms/deleteOrderForm.cs
+++ b/src/Publishing.UI/Forms/deleteOrderForm.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -10,6 +11,7 @@ namespace Publishing
     {
         private readonly INavigationService _navigation;
         private readonly IOrderRepository _orderRepo;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
         [Obsolete("Designer only", error: false)]
         public deleteOrderForm()
@@ -17,10 +19,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public deleteOrderForm(INavigationService navigation, IOrderRepository orderRepo)
+        public deleteOrderForm(INavigationService navigation, IOrderRepository orderRepo, IStringLocalizer<SharedResource> localizer)
         {
             _navigation = navigation;
             _orderRepo = orderRepo;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -32,7 +35,7 @@ namespace Publishing
 
                 await _orderRepo.DeleteAsync(idToDelete).ConfigureAwait(false);
 
-                MessageBox.Show("Видалено idOrder: " + idToDelete.ToString());
+                MessageBox.Show(string.Format(_localizer["DeleteOrderId"], idToDelete));
 
                 dataGridView1.Rows.RemoveAt(e.RowIndex);
             }

--- a/src/Publishing.UI/Forms/loginForm.cs
+++ b/src/Publishing.UI/Forms/loginForm.cs
@@ -2,6 +2,7 @@ using System;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
 using System.Windows.Forms;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -9,6 +10,7 @@ namespace Publishing
     {
         private readonly IAuthService _authService;
         private readonly INavigationService _navigation;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
         [Obsolete("Designer only", error: false)]
         public loginForm()
@@ -16,10 +18,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public loginForm(IAuthService authService, INavigationService navigation)
+        public loginForm(IAuthService authService, INavigationService navigation, IStringLocalizer<SharedResource> localizer)
         {
             _authService = authService;
             _navigation = navigation;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -38,11 +41,11 @@ namespace Publishing
                 CurrentUser.UserName = user.Name;
 
                 _navigation.Navigate<mainForm>(this);
-                MessageBox.Show("Вітаємо, " + CurrentUser.UserName + " (" + CurrentUser.UserType + ")!");
+                MessageBox.Show(_localizer["WelcomeUser", CurrentUser.UserName, CurrentUser.UserType]);
             }
             else
             {
-                MessageBox.Show("Невірна електронна пошта або пароль");
+                MessageBox.Show(_localizer["InvalidEmailOrPassword"]);
             }
         }
 

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -10,6 +11,7 @@ namespace Publishing
     {
         private readonly INavigationService _navigation;
         private readonly IOrganizationRepository _orgRepo;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
         [Obsolete("Designer only", error: false)]
         public organizationForm()
@@ -17,10 +19,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo)
+        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo, IStringLocalizer<SharedResource> localizer)
         {
             _navigation = navigation;
             _orgRepo = orgRepo;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -50,7 +53,7 @@ namespace Publishing
                 string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
                 if (!Regex.IsMatch(email, pattern))
                 {
-                    MessageBox.Show("Email is not valid");
+                    MessageBox.Show(_localizer["InvalidEmail"]);
                     return;
                 }
 
@@ -59,7 +62,7 @@ namespace Publishing
             else
             {
                 await _orgRepo.UpdateAsync(id, orgName, email, phone, fax, address).ConfigureAwait(false);
-                MessageBox.Show("Дані успішно змінено");
+                MessageBox.Show(_localizer["DataChanged"]);
 
                 _navigation.Navigate<mainForm>(this);
             }

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -10,6 +11,7 @@ namespace Publishing
     {
         private readonly INavigationService _navigation;
         private readonly IProfileRepository _profileRepo;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
         [Obsolete("Designer only", error: false)]
         public profileForm()
@@ -17,10 +19,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public profileForm(INavigationService navigation, IProfileRepository profileRepo)
+        public profileForm(INavigationService navigation, IProfileRepository profileRepo, IStringLocalizer<SharedResource> localizer)
         {
             _navigation = navigation;
             _profileRepo = profileRepo;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -43,7 +46,7 @@ namespace Publishing
             bool exists = await _profileRepo.EmailExistsAsync(email).ConfigureAwait(false);
             if (exists)
             {
-                MessageBox.Show("Email вже використовується");
+                MessageBox.Show(_localizer["EmailExists"]);
                 return;
             }
 
@@ -61,7 +64,7 @@ namespace Publishing
                 string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
                 if (!Regex.IsMatch(email, pattern))
                 {
-                    MessageBox.Show("Email is not valid");
+                    MessageBox.Show(_localizer["InvalidEmail"]);
                     return;
                 }
                 count++;
@@ -86,7 +89,7 @@ namespace Publishing
             {
                 await _profileRepo.UpdateAsync(id, fName, lName, email, status, phone, fax, address).ConfigureAwait(false);
 
-                MessageBox.Show("Дані успішно змінено");
+                MessageBox.Show(_localizer["DataChanged"]);
 
                 _navigation.Navigate<mainForm>(this);
             }

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
+using Microsoft.Extensions.Localization;
 
 namespace Publishing
 {
@@ -11,6 +12,7 @@ namespace Publishing
     {
         private readonly IAuthService _authService;
         private readonly INavigationService _navigation;
+        private readonly IStringLocalizer<SharedResource> _localizer;
 
         [Obsolete("Designer only", error: false)]
         public registrationForm()
@@ -18,10 +20,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public registrationForm(IAuthService authService, INavigationService navigation)
+        public registrationForm(IAuthService authService, INavigationService navigation, IStringLocalizer<SharedResource> localizer)
         {
             _authService = authService;
             _navigation = navigation;
+            _localizer = localizer;
             InitializeComponent();
         }
 
@@ -39,7 +42,7 @@ namespace Publishing
             string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
             if (!Regex.IsMatch(email, pattern))
             {
-                MessageBox.Show("Email is not valid");
+                MessageBox.Show(_localizer["InvalidEmail"]);
                 return;
             }
             string status = statusBox.SelectedItem?.ToString();
@@ -58,7 +61,7 @@ namespace Publishing
                 CurrentUser.UserName = user.Name;
 
                 _navigation.Navigate<mainForm>(this);
-                MessageBox.Show("Вітаємо, " + CurrentUser.UserName + " (" + CurrentUser.UserType + ")!");
+                MessageBox.Show(_localizer["WelcomeUser", CurrentUser.UserName, CurrentUser.UserType]);
             }
             catch (Exception ex)
             {

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Localization;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Publishing.Core.Interfaces;
@@ -24,6 +26,10 @@ namespace Publishing
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+            var culture = new CultureInfo("en-US");
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+
             var services = new ServiceCollection();
             ConfigureServices(services);
             Services = services.BuildServiceProvider();
@@ -44,6 +50,7 @@ namespace Publishing
 
         private static void ConfigureServices(ServiceCollection services)
         {
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
             services.AddScoped<IOrderRepository, OrderRepository>();
             services.AddScoped<IStatisticRepository, StatisticRepository>();
             services.AddScoped<IProfileRepository, ProfileRepository>();

--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -19,11 +19,13 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Resources\*.resx" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.UI/Resources/SharedResource.cs
+++ b/src/Publishing.UI/Resources/SharedResource.cs
@@ -1,0 +1,9 @@
+namespace Publishing
+{
+    /// <summary>
+    /// Marker class for shared localization resources.
+    /// </summary>
+    public class SharedResource
+    {
+    }
+}

--- a/src/Publishing.UI/Resources/SharedResource.resx
+++ b/src/Publishing.UI/Resources/SharedResource.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Resources.Extensions</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Resources.Extensions</value>
+  </resheader>
+  <data name="PagesNumParse" xml:space="preserve">
+    <value>Invalid page number</value>
+  </data>
+  <data name="TirageParse" xml:space="preserve">
+    <value>Invalid tirage number</value>
+  </data>
+  <data name="OrderAdded" xml:space="preserve">
+    <value>Order successfully added</value>
+  </data>
+  <data name="DeleteOrderId" xml:space="preserve">
+    <value>Deleted order id {0}</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Welcome, {0} ({1})!</value>
+  </data>
+  <data name="InvalidEmailOrPassword" xml:space="preserve">
+    <value>Invalid email or password</value>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>Email is not valid</value>
+  </data>
+  <data name="DataChanged" xml:space="preserve">
+    <value>Data successfully changed</value>
+  </data>
+  <data name="EmailExists" xml:space="preserve">
+    <value>Email already in use</value>
+  </data>
+</root>

--- a/src/Publishing.UI/Resources/SharedResource.uk.resx
+++ b/src/Publishing.UI/Resources/SharedResource.uk.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Resources.Extensions</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Resources.Extensions</value>
+  </resheader>
+  <data name="PagesNumParse" xml:space="preserve">
+    <value>Невірне значення кількості сторінок</value>
+  </data>
+  <data name="TirageParse" xml:space="preserve">
+    <value>Невірний наклад</value>
+  </data>
+  <data name="OrderAdded" xml:space="preserve">
+    <value>Замовлення успішно додано</value>
+  </data>
+  <data name="DeleteOrderId" xml:space="preserve">
+    <value>Видалено idOrder: {0}</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Вітаємо, {0} ({1})!</value>
+  </data>
+  <data name="InvalidEmailOrPassword" xml:space="preserve">
+    <value>Невірна електронна пошта або пароль</value>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>Email некоректний</value>
+  </data>
+  <data name="DataChanged" xml:space="preserve">
+    <value>Дані успішно змінено</value>
+  </data>
+  <data name="EmailExists" xml:space="preserve">
+    <value>Email вже використовується</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add `.editorconfig` with basic formatting rules
- introduce localization resources and service registration
- inject `IStringLocalizer` into UI forms and use for user messages
- include English and Ukrainian resources

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854518f2a248320a7a8751c6cb75684