### PR TITLE
Fix connection disposal

### DIFF
--- a/src/Publishing.Infrastructure/SqlDbContext.cs
+++ b/src/Publishing.Infrastructure/SqlDbContext.cs
@@ -16,13 +16,13 @@ namespace Publishing.Infrastructure
 
         public async Task<IEnumerable<T>> QueryAsync<T>(string sql, object? param = null)
         {
-            await using var con = await _connectionFactory.CreateOpenConnectionAsync();
+            using var con = await _connectionFactory.CreateOpenConnectionAsync();
             return await con.QueryAsync<T>(sql, param);
         }
 
         public async Task<int> ExecuteAsync(string sql, object? param = null)
         {
-            await using var con = await _connectionFactory.CreateOpenConnectionAsync();
+            using var con = await _connectionFactory.CreateOpenConnectionAsync();
             return await con.ExecuteAsync(sql, param);
         }
     }

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -57,8 +57,8 @@ namespace Publishing
                 .Build();
 
             services.AddSingleton<IConfiguration>(configuration);
-            services.AddSingleton<IDbConnectionFactory, SqlDbConnectionFactory>();
-            services.AddScoped<IDbContext, SqlDbContext>();
+            services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
+            services.AddTransient<IDbContext, SqlDbContext>();
             services.AddScoped<IDbHelper, DbHelper>();
             services.AddScoped<ILoginRepository, LoginRepository>();
             services.AddScoped<IAuthService, AuthService>();

--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -16,14 +16,14 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- use ordinary `using` for connections to avoid CS8417
- register DB connection factory and context as transient services
- ensure UI project references correct DI and configuration packages

## Testing
- `dotnet build Publishing.sln` *(fails: `dotnet` not found)*
- `dotnet test Publishing.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854569a1a808320afffc62406147da8