### PR TITLE
Fix MSTest packages

### DIFF
--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />


### PR DESCRIPTION
## Summary
- switch to MSTest packages for Publishing.Core.Tests

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545c6019bc8320883c1cd407866493