### PR TITLE
Fix EF Core snapshot version

### DIFF
--- a/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -10,7 +10,7 @@ namespace Publishing.Infrastructure.Migrations
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+            modelBuilder.HasAnnotation("ProductVersion", "6.0.22");
 
             modelBuilder.Entity<Person>(entity =>
             {


### PR DESCRIPTION
## Summary
- update migration snapshot for EF Core 6

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547d6241ac83208d33712eb121396e