### PR TITLE
Ensure EF CLI uses version 6 and simplify init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 6.0.x
     - name: Install EF Core CLI
-      run: dotnet tool install --global dotnet-ef
+      run: dotnet tool install --global dotnet-ef --version 6.0.*
     - name: Add dotnet-ef to PATH
       run: echo "${{ env.USERPROFILE }}\\.dotnet\\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Restore

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `Publishing.UI` project contains an `appsettings.json` file with a default c
 1. Install the EF Core tools if needed:
 
 ```bash
- dotnet tool install --global dotnet-ef
+ dotnet tool install --global dotnet-ef --version 6.0.*
 ```
 
 2. Add a new migration from the `Publishing.Infrastructure` project directory:

--- a/src/Publishing.Infrastructure/DatabaseInitializer.cs
+++ b/src/Publishing.Infrastructure/DatabaseInitializer.cs
@@ -14,7 +14,10 @@ namespace Publishing.Infrastructure
 
         public Task InitializeAsync()
         {
-            return _context.Database.MigrateAsync();
+            // For simpler integration testing we ensure the schema exists
+            // rather than running migrations. This works because the model is
+            // kept in sync with EF Core 6.
+            return _context.Database.EnsureCreatedAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- run `EnsureCreated` when initializing the database
- use dotnet 6 and EF Core CLI 6.x in the CI workflow
- update README to install dotnet-ef 6

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685480492ee88320b699a57a13644078