### PR TITLE
Allow Orders.ProductId to be nullable

### DIFF
--- a/src/Publishing.Infrastructure/AppDbContext.cs
+++ b/src/Publishing.Infrastructure/AppDbContext.cs
@@ -62,7 +62,9 @@ namespace Publishing.Infrastructure
                 entity.ToTable("Orders");
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).HasColumnName("idOrder");
-                entity.Property(e => e.ProductId).HasColumnName("idProduct");
+                entity.Property(e => e.ProductId)
+                      .HasColumnName("idProduct")
+                      .IsRequired(false);
                 entity.Property(e => e.PersonId).HasColumnName("idPerson");
                 entity.Property(e => e.NamePrintery).HasColumnName("namePrintery");
                 entity.Property(e => e.DateOrder).HasColumnName("dateOrder");

--- a/src/Publishing.Infrastructure/Entities/Order.cs
+++ b/src/Publishing.Infrastructure/Entities/Order.cs
@@ -6,7 +6,7 @@ namespace Publishing.Infrastructure.Entities
     public class Order
     {
         public int Id { get; set; }
-        public int ProductId { get; set; }
+        public int? ProductId { get; set; }
         public int PersonId { get; set; }
         public string NamePrintery { get; set; } = string.Empty;
         public DateTime DateOrder { get; set; }

--- a/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -57,7 +57,9 @@ namespace Publishing.Infrastructure.Migrations
                 entity.ToTable("Orders");
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).HasColumnName("idOrder");
-                entity.Property(e => e.ProductId).HasColumnName("idProduct");
+                entity.Property(e => e.ProductId)
+                      .HasColumnName("idProduct")
+                      .IsRequired(false);
                 entity.Property(e => e.PersonId).HasColumnName("idPerson");
                 entity.Property(e => e.NamePrintery).HasColumnName("namePrintery");
                 entity.Property(e => e.DateOrder).HasColumnName("dateOrder");

--- a/src/Publishing.Infrastructure/Migrations/InitialCreate.cs
+++ b/src/Publishing.Infrastructure/Migrations/InitialCreate.cs
@@ -74,7 +74,7 @@ namespace Publishing.Infrastructure.Migrations
                 {
                     idOrder = table.Column<int>(nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    idProduct = table.Column<int>(nullable: false),
+                    idProduct = table.Column<int>(nullable: true),
                     idPerson = table.Column<int>(nullable: false),
                     namePrintery = table.Column<string>(nullable: false),
                     dateOrder = table.Column<DateTime>(nullable: false),


### PR DESCRIPTION
## Summary
- make `Order.ProductId` nullable
- mark `Order.ProductId` as optional in EF model configuration
- update the migration and snapshot so `idProduct` is nullable

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854850cd00083209eab67b33f849066