### PR TITLE
Fix missing EF Core provider reference

### DIFF
--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.22" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.22" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Publishing.Core\Publishing.Core.csproj" />


### PR DESCRIPTION
## Summary
- add Microsoft.EntityFrameworkCore.InMemory package to Publishing.Core.Tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548fb53f448320994783c6c93ca35f