### PR TITLE
Fix migrations not compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository hosts a simple publishing workflow demo. Database schema is main
 
 The `Publishing.UI` project contains an `appsettings.json` file with a default connection string pointing to LocalDB.  The project file copies this file to the output directory so both the application and `dotnet ef` commands can use it automatically. During startup a dedicated initializer applies pending EF Core migrations so the schema stays in sync with the models.
 
+The infrastructure project explicitly includes all migration files as `<Compile>` items so they are part of the final assembly. This ensures `Database.MigrateAsync()` can locate migrations during integration tests.
+
 ## Working with migrations
 
 1. Install the EF Core tools if needed:

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -27,4 +27,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Ensure EF Core migrations are compiled into the assembly -->
+  <ItemGroup>
+    <Compile Include="Migrations\**\*.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add migration compile item to infrastructure project
- document migration compile step in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685495d7b3248320943568b0a478a242