### PR TITLE
Fix duplicate compile items for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository hosts a simple publishing workflow demo. Database schema is main
 
 The `Publishing.UI` project contains an `appsettings.json` file with a default connection string pointing to LocalDB.  The project file copies this file to the output directory so both the application and `dotnet ef` commands can use it automatically. During startup a dedicated initializer applies pending EF Core migrations so the schema stays in sync with the models.
 
-The infrastructure project explicitly includes all migration files as `<Compile>` items so they are part of the final assembly. This ensures `Database.MigrateAsync()` can locate migrations during integration tests.
+All EF Core migration files are compiled automatically since .NET SDK includes all `*.cs` files by default. This ensures `Database.MigrateAsync()` can locate migrations during integration tests.
 
 ## Working with migrations
 

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -27,9 +27,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Ensure EF Core migrations are compiled into the assembly -->
-  <ItemGroup>
-    <Compile Include="Migrations\**\*.cs" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- drop explicit Compile Include for EF Core migrations
- clarify README about automatic migration compilation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549f2420ec8320b9b499849bd334c8