### PR TITLE
Add migration diagnostics in integration tests

### DIFF
--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -60,8 +60,16 @@ CREATE DATABASE [{DbName}];";
 
             _serviceProvider = services.BuildServiceProvider();
             using var scope = _serviceProvider.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var pending = ctx.Database.GetPendingMigrations().ToList();
+            Console.WriteLine($"[CrudFlow] Pending before migrate: {string.Join(", ", pending)}");
+
             scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
                 .InitializeAsync().Wait();
+
+            pending = ctx.Database.GetPendingMigrations().ToList();
+            Console.WriteLine($"[CrudFlow] Pending after  migrate: {string.Join(", ", pending)}");
+
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
         }
 

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -58,8 +58,15 @@ CREATE DATABASE [{DbName}];";
             _serviceProvider = services.BuildServiceProvider();
 
             using var scope = _serviceProvider.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var pending = ctx.Database.GetPendingMigrations().ToList();
+            Console.WriteLine($"[Statistic] Pending before migrate: {string.Join(", ", pending)}");
+
             scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
                 .InitializeAsync().Wait();
+
+            pending = ctx.Database.GetPendingMigrations().ToList();
+            Console.WriteLine($"[Statistic] Pending after  migrate: {string.Join(", ", pending)}");
 
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
             _helper = scope.ServiceProvider.GetRequiredService<IDbHelper>();


### PR DESCRIPTION
## Summary
- write pending migration info during setup of **CrudFlowTests** and **StatisticTests** to debug why migrations don't run

## Testing
- `dotnet test --filter FullyQualifiedName~Publishing.Integration.Tests` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a09727a88320a287ec39695d20dd