### PR TITLE
Fix migrations visibility for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ This repository hosts a simple publishing workflow demo. Database schema is main
 
 The `Publishing.UI` project contains an `appsettings.json` file with a default connection string pointing to LocalDB.  The project file copies this file to the output directory so both the application and `dotnet ef` commands can use it automatically. During startup a dedicated initializer applies pending EF Core migrations so the schema stays in sync with the models.
 
-All EF Core migration files are compiled automatically since .NET SDK includes all `*.cs` files by default. This ensures `Database.MigrateAsync()` can locate migrations during integration tests.
+All EF Core migration files must be compiled so `Database.MigrateAsync()` can locate them during integration tests. If the EF tools added them as `None` items, ensure they are built with:
+
+```xml
+<ItemGroup>
+  <Compile Update="Migrations\**\*.cs" />
+</ItemGroup>
+```
 
 ## Working with migrations
 

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -27,4 +27,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Ensure EF Core migrations are compiled into the assembly -->
+  <ItemGroup>
+    <Compile Update="Migrations\**\*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -60,16 +60,8 @@ CREATE DATABASE [{DbName}];";
 
             _serviceProvider = services.BuildServiceProvider();
             using var scope = _serviceProvider.CreateScope();
-            var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            var pending = ctx.Database.GetPendingMigrations().ToList();
-            Console.WriteLine($"[CrudFlow] Pending before migrate: {string.Join(", ", pending)}");
-
             scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
                 .InitializeAsync().Wait();
-
-            pending = ctx.Database.GetPendingMigrations().ToList();
-            Console.WriteLine($"[CrudFlow] Pending after  migrate: {string.Join(", ", pending)}");
-
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
         }
 

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -58,16 +58,8 @@ CREATE DATABASE [{DbName}];";
             _serviceProvider = services.BuildServiceProvider();
 
             using var scope = _serviceProvider.CreateScope();
-            var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            var pending = ctx.Database.GetPendingMigrations().ToList();
-            Console.WriteLine($"[Statistic] Pending before migrate: {string.Join(", ", pending)}");
-
             scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
                 .InitializeAsync().Wait();
-
-            pending = ctx.Database.GetPendingMigrations().ToList();
-            Console.WriteLine($"[Statistic] Pending after  migrate: {string.Join(", ", pending)}");
-
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
             _helper = scope.ServiceProvider.GetRequiredService<IDbHelper>();
 


### PR DESCRIPTION
## Summary
- compile EF Core migrations so that `Database.MigrateAsync()` can locate them
- remove temporary migration diagnostics from integration tests
- document how to include migrations in the build

## Testing
- `dotnet ef migrations list --project src/Publishing.Infrastructure` *(fails: dotnet not found)*
- `dotnet test --filter FullyQualifiedName~Publishing.Integration.Tests` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a21e96948320b86e279c7661b4de