### PR TITLE
Fix cascade paths for Orders table

### DIFF
--- a/src/Publishing.Infrastructure/AppDbContext.cs
+++ b/src/Publishing.Infrastructure/AppDbContext.cs
@@ -81,7 +81,7 @@ namespace Publishing.Infrastructure
                 entity.HasOne(e => e.Person)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.PersonId)
-                      .OnDelete(DeleteBehavior.Restrict);
+                      .OnDelete(DeleteBehavior.Cascade);
             });
         }
     }

--- a/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.Designer.cs
+++ b/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.Designer.cs
@@ -73,7 +73,8 @@ namespace Publishing.Infrastructure.Migrations
                 entity.Property(e => e.Price).HasColumnName("price");
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
-                      .HasForeignKey(e => e.ProductId);
+                      .HasForeignKey(e => e.ProductId)
+                      .OnDelete(DeleteBehavior.Restrict);
                 entity.HasOne(e => e.Person)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.PersonId);

--- a/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.cs
+++ b/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.cs
@@ -80,7 +80,7 @@ namespace Publishing.Infrastructure.Migrations
                         column: x => x.idProduct,
                         principalTable: "Product",
                         principalColumn: "idProduct",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.NoAction);
                 });
 
             migrationBuilder.CreateIndex(

--- a/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -72,7 +72,8 @@ namespace Publishing.Infrastructure.Migrations
                 entity.Property(e => e.Price).HasColumnName("price");
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
-                      .HasForeignKey(e => e.ProductId);
+                      .HasForeignKey(e => e.ProductId)
+                      .OnDelete(DeleteBehavior.Restrict);
                 entity.HasOne(e => e.Person)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.PersonId);


### PR DESCRIPTION
## Summary
- set cascade delete only on `Person` and restrict delete for `Product`
- update initial migration files to match the model

## Testing
- `dotnet test --filter FullyQualifiedName~Publishing.Integration.Tests` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553185ef1083208ea10e9b3aa2d5be