### PR TITLE
Switch price column to decimal

### DIFF
--- a/src/Publishing.Infrastructure/Entities/Order.cs
+++ b/src/Publishing.Infrastructure/Entities/Order.cs
@@ -14,7 +14,7 @@ namespace Publishing.Infrastructure.Entities
         public DateTime DateFinish { get; set; }
         public string Status { get; set; } = string.Empty;
         public int Tirage { get; set; }
-        public int Price { get; set; }
+        public decimal Price { get; set; }
 
         public Person Person { get; set; } = null!;
         public Product Product { get; set; } = null!;

--- a/src/Publishing.Infrastructure/Migrations/20250620000000_AddPersonTable.Designer.cs
+++ b/src/Publishing.Infrastructure/Migrations/20250620000000_AddPersonTable.Designer.cs
@@ -70,7 +70,9 @@ namespace Publishing.Infrastructure.Migrations
                 entity.Property(e => e.DateFinish).HasColumnName("dateFinish");
                 entity.Property(e => e.Status).HasColumnName("statusOrder");
                 entity.Property(e => e.Tirage).HasColumnName("tirage");
-                entity.Property(e => e.Price).HasColumnName("price");
+                entity.Property(e => e.Price)
+                      .HasColumnType("decimal(18,2)")
+                      .HasColumnName("price");
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.ProductId);

--- a/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.Designer.cs
+++ b/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.Designer.cs
@@ -70,7 +70,9 @@ namespace Publishing.Infrastructure.Migrations
                 entity.Property(e => e.DateFinish).HasColumnName("dateFinish");
                 entity.Property(e => e.Status).HasColumnName("statusOrder");
                 entity.Property(e => e.Tirage).HasColumnName("tirage");
-                entity.Property(e => e.Price).HasColumnName("price");
+                entity.Property(e => e.Price)
+                      .HasColumnType("decimal(18,2)")
+                      .HasColumnName("price");
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.ProductId)

--- a/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.cs
+++ b/src/Publishing.Infrastructure/Migrations/20250620000001_AddProductPassOrdersTables.cs
@@ -64,7 +64,7 @@ namespace Publishing.Infrastructure.Migrations
                     dateFinish = table.Column<DateTime>(nullable: false),
                     statusOrder = table.Column<string>(nullable: false),
                     tirage = table.Column<int>(nullable: false),
-                    price = table.Column<int>(nullable: false)
+                    price = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Publishing.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -69,7 +69,9 @@ namespace Publishing.Infrastructure.Migrations
                 entity.Property(e => e.DateFinish).HasColumnName("dateFinish");
                 entity.Property(e => e.Status).HasColumnName("statusOrder");
                 entity.Property(e => e.Tirage).HasColumnName("tirage");
-                entity.Property(e => e.Price).HasColumnName("price");
+                entity.Property(e => e.Price)
+                      .HasColumnType("decimal(18,2)")
+                      .HasColumnName("price");
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.ProductId)

--- a/src/Publishing.Infrastructure/Migrations/InitialCreate.cs
+++ b/src/Publishing.Infrastructure/Migrations/InitialCreate.cs
@@ -82,7 +82,7 @@ namespace Publishing.Infrastructure.Migrations
                     dateFinish = table.Column<DateTime>(nullable: false),
                     statusOrder = table.Column<string>(nullable: false),
                     tirage = table.Column<int>(nullable: false),
-                    price = table.Column<int>(nullable: false)
+                    price = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
                 },
                 constraints: table =>
                 {


### PR DESCRIPTION
## Summary
- use `decimal` for `Order.Price`
- update EF Core migrations to create a decimal `price` column

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554fb3f0208320aac65ee742ff1d77