### PR TITLE
Fix Windows Forms Application name collision

### DIFF
--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -29,7 +29,7 @@ namespace Publishing
 
         private void addOrderForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void змінитиДаніToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/deleteOrderForm.cs
+++ b/src/Publishing.UI/Forms/deleteOrderForm.cs
@@ -40,7 +40,7 @@ namespace Publishing
 
         private void deleteOrderForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void змінитиДаніToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/loginForm.cs
+++ b/src/Publishing.UI/Forms/loginForm.cs
@@ -53,7 +53,7 @@ namespace Publishing
 
         private void LoginForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void loginForm_Load(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/mainForm.cs
+++ b/src/Publishing.UI/Forms/mainForm.cs
@@ -26,7 +26,7 @@ namespace Publishing
 
         private void mainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void вийтиToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -31,7 +31,7 @@ namespace Publishing
 
         private void organizationForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private async void changeButton_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -26,7 +26,7 @@ namespace Publishing
 
         private void profileForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private async void changeButton_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -68,7 +68,7 @@ namespace Publishing
 
         private void registrationForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void registrationForm_Load(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/statisticForm.cs
+++ b/src/Publishing.UI/Forms/statisticForm.cs
@@ -54,7 +54,7 @@ namespace Publishing
 
         private void statisticForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Application.Exit();
+            System.Windows.Forms.Application.Exit();
         }
 
         private void вийтиToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -28,8 +28,8 @@ namespace Publishing
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
+            System.Windows.Forms.Application.EnableVisualStyles();
+            System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
 
             var services = new ServiceCollection();
             ConfigureServices(services);
@@ -43,7 +43,7 @@ namespace Publishing
             }
 
             var form = Services.GetRequiredService<loginForm>();
-            Application.Run(form);
+            System.Windows.Forms.Application.Run(form);
 
             if (Services is IDisposable d)
             {


### PR DESCRIPTION
## Summary
- namespace `Publishing.Application` conflicted with `System.Windows.Forms.Application`
- qualify the Windows Forms `Application` calls in Program and form classes

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855560f38888320b2ecc5e78c047d7e