### PR TITLE
Rename application layer namespace

### DIFF
--- a/Publishing.sln
+++ b/Publishing.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Infrastructure",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Services", "src\Publishing.Services\Publishing.Services.csproj", "{FF727600-00AE-423C-BBDF-79CE9A936887}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Application", "src\Publishing.Application\Publishing.Application.csproj", "{9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.AppLayer", "src\Publishing.Application\Publishing.Application.csproj", "{9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Publishing.Application/Behaviors/ValidationBehavior.cs
+++ b/src/Publishing.Application/Behaviors/ValidationBehavior.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using FluentValidation;
 using MediatR;
 
-namespace Publishing.Application.Behaviors
+namespace Publishing.AppLayer.Behaviors
 {
     public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
         where TRequest : notnull

--- a/src/Publishing.Application/Commands/CreateOrderCommand.cs
+++ b/src/Publishing.Application/Commands/CreateOrderCommand.cs
@@ -1,7 +1,7 @@
 using MediatR;
 using Publishing.Core.Domain;
 
-namespace Publishing.Application.Commands
+namespace Publishing.AppLayer.Commands
 {
     public record CreateOrderCommand(
         string Type,

--- a/src/Publishing.Application/Handlers/CreateOrderHandler.cs
+++ b/src/Publishing.Application/Handlers/CreateOrderHandler.cs
@@ -2,12 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using Publishing.Application.Commands;
+using Publishing.AppLayer.Commands;
 using Publishing.Core.Domain;
 using Publishing.Core.Interfaces;
 using FluentValidation;
 
-namespace Publishing.Application.Handlers
+namespace Publishing.AppLayer.Handlers
 {
     public class CreateOrderHandler : IRequestHandler<CreateOrderCommand, Order>
     {

--- a/src/Publishing.Application/Publishing.Application.csproj
+++ b/src/Publishing.Application/Publishing.Application.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace>Publishing.AppLayer</RootNamespace>
+    <AssemblyName>Publishing.AppLayer</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.1.1" />

--- a/src/Publishing.Application/Validators/CreateOrderValidator.cs
+++ b/src/Publishing.Application/Validators/CreateOrderValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using Publishing.Application.Commands;
+using Publishing.AppLayer.Commands;
 
-namespace Publishing.Application.Validators
+namespace Publishing.AppLayer.Validators
 {
     public class CreateOrderValidator : AbstractValidator<CreateOrderCommand>
     {

--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -4,7 +4,7 @@ using Publishing.Core.Interfaces;
 using System.Windows.Forms;
 using Publishing.Services;
 using MediatR;
-using Publishing.Application.Commands;
+using Publishing.AppLayer.Commands;
 using System.Resources;
 
 namespace Publishing

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -12,9 +12,9 @@ using Publishing.Infrastructure;
 using Publishing.Infrastructure.Repositories;
 using Publishing.Infrastructure.Queries;
 using MediatR;
-using Publishing.Application.Handlers;
-using Publishing.Application.Validators;
-using Publishing.Application.Behaviors;
+using Publishing.AppLayer.Handlers;
+using Publishing.AppLayer.Validators;
+using Publishing.AppLayer.Behaviors;
 using FluentValidation;
 using Publishing.Services;
 

--- a/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Publishing.Application.Commands;
-using Publishing.Application.Handlers;
-using Publishing.Application.Validators;
+using Publishing.AppLayer.Commands;
+using Publishing.AppLayer.Handlers;
+using Publishing.AppLayer.Validators;
 using Publishing.Core.Domain;
 using Publishing.Core.Interfaces;
 using Publishing.Core.Services;


### PR DESCRIPTION
## Summary
- rename Publishing.Application to Publishing.AppLayer to prevent conflicts with `System.Windows.Forms.Application`
- update namespaces and `using` directives
- keep project references the same while changing project display name

## Testing
- `dotnet clean` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685556562c0883208628e32f946ba35e