### PR TITLE
Implement reusable email validator

### DIFF
--- a/src/Publishing.Application/Validators/EmailValidator.cs
+++ b/src/Publishing.Application/Validators/EmailValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Publishing.AppLayer.Validators
+{
+    public class EmailValidator : AbstractValidator<string>
+    {
+        public EmailValidator()
+        {
+            RuleFor(x => x).NotEmpty().EmailAddress();
+        }
+    }
+}

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using FluentValidation;
 
 namespace Publishing
 {
@@ -10,6 +10,7 @@ namespace Publishing
     {
         private readonly INavigationService _navigation;
         private readonly IOrganizationRepository _orgRepo;
+        private readonly IValidator<string> _emailValidator;
 
         [Obsolete("Designer only", error: false)]
         public organizationForm()
@@ -17,10 +18,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo)
+        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo, IValidator<string> emailValidator)
         {
             _navigation = navigation;
             _orgRepo = orgRepo;
+            _emailValidator = emailValidator;
             InitializeComponent();
         }
 
@@ -47,8 +49,8 @@ namespace Publishing
 
             if (!orgName.Equals(checkName))
             {
-                string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-                if (!Regex.IsMatch(email, pattern))
+                var result = _emailValidator.Validate(email);
+                if (!result.IsValid)
                 {
                     MessageBox.Show("Email is not valid");
                     return;

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using FluentValidation;
 
 namespace Publishing
 {
@@ -10,6 +10,7 @@ namespace Publishing
     {
         private readonly INavigationService _navigation;
         private readonly IProfileRepository _profileRepo;
+        private readonly IValidator<string> _emailValidator;
 
         [Obsolete("Designer only", error: false)]
         public profileForm()
@@ -17,10 +18,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public profileForm(INavigationService navigation, IProfileRepository profileRepo)
+        public profileForm(INavigationService navigation, IProfileRepository profileRepo, IValidator<string> emailValidator)
         {
             _navigation = navigation;
             _profileRepo = profileRepo;
+            _emailValidator = emailValidator;
             InitializeComponent();
         }
 
@@ -58,8 +60,8 @@ namespace Publishing
             }
             if (email != "")
             {
-                string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-                if (!Regex.IsMatch(email, pattern))
+                var result = _emailValidator.Validate(email);
+                if (!result.IsValid)
                 {
                     MessageBox.Show("Email is not valid");
                     return;

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
+using FluentValidation;
 
 namespace Publishing
 {
@@ -11,6 +11,7 @@ namespace Publishing
     {
         private readonly IAuthService _authService;
         private readonly INavigationService _navigation;
+        private readonly IValidator<string> _emailValidator;
 
         [Obsolete("Designer only", error: false)]
         public registrationForm()
@@ -18,10 +19,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public registrationForm(IAuthService authService, INavigationService navigation)
+        public registrationForm(IAuthService authService, INavigationService navigation, IValidator<string> emailValidator)
         {
             _authService = authService;
             _navigation = navigation;
+            _emailValidator = emailValidator;
             InitializeComponent();
         }
 
@@ -36,8 +38,8 @@ namespace Publishing
             string fName = FNameTextBox.Text;
             string lName = LNameTextBox.Text;
             string email = emailTextBox.Text;
-            string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-            if (!Regex.IsMatch(email, pattern))
+            var result = _emailValidator.Validate(email);
+            if (!result.IsValid)
             {
                 MessageBox.Show("Email is not valid");
                 return;

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -69,6 +69,7 @@ namespace Publishing
             services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
             services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderHandler).Assembly));
             services.AddValidatorsFromAssemblyContaining<CreateOrderValidator>();
+            services.AddValidatorsFromAssemblyContaining<EmailValidator>();
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
             var configuration = new ConfigurationBuilder()

--- a/src/tests/Publishing.Core.Tests/EmailValidatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/EmailValidatorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text.RegularExpressions;
+using Publishing.AppLayer.Validators;
+using FluentValidation;
 using System.Threading.Tasks;
 using System.Data;
 
@@ -8,8 +9,6 @@ namespace Publishing.Core.Tests
     [TestClass]
     public class EmailValidatorTests
     {
-        private const string Pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-
         [DataTestMethod]
         [DataRow("test@example.com", true)]
         [DataRow("user.name@domain.co", true)]
@@ -17,7 +16,8 @@ namespace Publishing.Core.Tests
         [DataRow("another@invalid", false)]
         public void RegistrationForm_EmailValidation(string email, bool expected)
         {
-            bool result = Regex.IsMatch(email, Pattern);
+            var validator = new EmailValidator();
+            bool result = validator.Validate(email).IsValid;
             Assert.AreEqual(expected, result);
         }
 
@@ -26,7 +26,8 @@ namespace Publishing.Core.Tests
         [DataRow("wrong@address", false)]
         public void OrganizationForm_EmailValidation(string email, bool expected)
         {
-            bool result = Regex.IsMatch(email, Pattern);
+            var validator = new EmailValidator();
+            bool result = validator.Validate(email).IsValid;
             Assert.AreEqual(expected, result);
         }
     }


### PR DESCRIPTION
## Summary
- add `EmailValidator` class using FluentValidation
- register validator in `Program.ConfigureServices`
- use validator in `profileForm`, `registrationForm`, and `organizationForm`
- update tests to use new validator

## Testing
- ❌ `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685560a01cd88320a52829889e744fe8