### PR TITLE
Fix session usage and centralize email validation

### DIFF
--- a/src/Publishing.Application/Validators/EmailValidator.cs
+++ b/src/Publishing.Application/Validators/EmailValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Publishing.AppLayer.Validators
+{
+    public class EmailValidator : AbstractValidator<string>
+    {
+        public EmailValidator()
+        {
+            RuleFor(x => x).NotEmpty().EmailAddress();
+        }
+    }
+}

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Text.RegularExpressions;
+using FluentValidation;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
@@ -11,6 +11,7 @@ namespace Publishing
         private readonly INavigationService _navigation;
         private readonly IOrganizationRepository _orgRepo;
         private readonly IUserSession _session;
+        private readonly IValidator<string> _validator;
 
         [Obsolete("Designer only", error: false)]
         public organizationForm()
@@ -18,11 +19,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo, IUserSession session)
+        public organizationForm(INavigationService navigation, IOrganizationRepository orgRepo, IUserSession session, IValidator<string> validator)
         {
             _navigation = navigation;
             _orgRepo = orgRepo;
             _session = session;
+            _validator = validator;
             InitializeComponent();
         }
 
@@ -49,8 +51,7 @@ namespace Publishing
 
             if (!orgName.Equals(checkName))
             {
-                string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-                if (!Regex.IsMatch(email, pattern))
+                if (!_validator.Validate(email).IsValid)
                 {
                     MessageBox.Show("Email is not valid");
                     return;

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Text.RegularExpressions;
+using FluentValidation;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
@@ -11,6 +11,7 @@ namespace Publishing
         private readonly INavigationService _navigation;
         private readonly IProfileRepository _profileRepo;
         private readonly IUserSession _session;
+        private readonly IValidator<string> _validator;
 
         [Obsolete("Designer only", error: false)]
         public profileForm()
@@ -18,11 +19,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public profileForm(INavigationService navigation, IProfileRepository profileRepo, IUserSession session)
+        public profileForm(INavigationService navigation, IProfileRepository profileRepo, IUserSession session, IValidator<string> validator)
         {
             _navigation = navigation;
             _profileRepo = profileRepo;
             _session = session;
+            _validator = validator;
             InitializeComponent();
         }
 
@@ -60,8 +62,7 @@ namespace Publishing
             }
             if (email != "")
             {
-                string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-                if (!Regex.IsMatch(email, pattern))
+                if (!_validator.Validate(email).IsValid)
                 {
                     MessageBox.Show("Email is not valid");
                     return;

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using FluentValidation;
 using System.Windows.Forms;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
@@ -12,6 +12,7 @@ namespace Publishing
         private readonly IAuthService _authService;
         private readonly INavigationService _navigation;
         private readonly IUserSession _session;
+        private readonly IValidator<string> _validator;
 
         [Obsolete("Designer only", error: false)]
         public registrationForm()
@@ -19,11 +20,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public registrationForm(IAuthService authService, INavigationService navigation, IUserSession session)
+        public registrationForm(IAuthService authService, INavigationService navigation, IUserSession session, IValidator<string> validator)
         {
             _authService = authService;
             _navigation = navigation;
             _session = session;
+            _validator = validator;
             InitializeComponent();
         }
 
@@ -38,8 +40,7 @@ namespace Publishing
             string fName = FNameTextBox.Text;
             string lName = LNameTextBox.Text;
             string email = emailTextBox.Text;
-            string pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
-            if (!Regex.IsMatch(email, pattern))
+            if (!_validator.Validate(email).IsValid)
             {
                 MessageBox.Show("Email is not valid");
                 return;

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -67,9 +67,10 @@ namespace Publishing
             services.AddScoped<IPriceCalculator, PriceCalculator>();
             services.AddScoped<IOrderValidator, OrderValidator>();
             services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
-            services.AddScoped<IUserSession, UserSession>();
+            services.AddSingleton<IUserSession, UserSession>();
             services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderHandler).Assembly));
-            services.AddValidatorsFromAssemblyContaining<CreateOrderValidator>();
+            services.AddValidatorsFromAssemblyContaining<EmailValidator>();
+            services.AddSingleton<IValidator<string>, EmailValidator>();
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
             var configuration = new ConfigurationBuilder()

--- a/src/tests/Publishing.Core.Tests/EmailValidatorTests.cs
+++ b/src/tests/Publishing.Core.Tests/EmailValidatorTests.cs
@@ -1,14 +1,13 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Data;
+using FluentValidation;
+using Publishing.AppLayer.Validators;
 
 namespace Publishing.Core.Tests
 {
     [TestClass]
     public class EmailValidatorTests
     {
-        private const string Pattern = @"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$";
+        private readonly IValidator<string> _validator = new EmailValidator();
 
         [DataTestMethod]
         [DataRow("test@example.com", true)]
@@ -17,7 +16,7 @@ namespace Publishing.Core.Tests
         [DataRow("another@invalid", false)]
         public void RegistrationForm_EmailValidation(string email, bool expected)
         {
-            bool result = Regex.IsMatch(email, Pattern);
+            bool result = _validator.Validate(email).IsValid;
             Assert.AreEqual(expected, result);
         }
 
@@ -26,7 +25,7 @@ namespace Publishing.Core.Tests
         [DataRow("wrong@address", false)]
         public void OrganizationForm_EmailValidation(string email, bool expected)
         {
-            bool result = Regex.IsMatch(email, Pattern);
+            bool result = _validator.Validate(email).IsValid;
             Assert.AreEqual(expected, result);
         }
     }

--- a/src/tests/Publishing.Core.Tests/UserSessionTests.cs
+++ b/src/tests/Publishing.Core.Tests/UserSessionTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Services;
+
+namespace Publishing.Core.Tests
+{
+    [TestClass]
+    public class UserSessionTests
+    {
+        [TestMethod]
+        public void Properties_SetAndClear_WorkCorrectly()
+        {
+            var session = new UserSession();
+            session.UserId = "42";
+            session.UserName = "Alice";
+            session.UserType = "admin";
+
+            Assert.AreEqual("42", session.UserId);
+            Assert.AreEqual("Alice", session.UserName);
+            Assert.AreEqual("admin", session.UserType);
+
+            session.UserId = string.Empty;
+            session.UserName = string.Empty;
+            session.UserType = string.Empty;
+
+            Assert.AreEqual(string.Empty, session.UserId);
+            Assert.AreEqual(string.Empty, session.UserName);
+            Assert.AreEqual(string.Empty, session.UserType);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `EmailValidator` with FluentValidation
- inject validator and `IUserSession` into forms
- register `EmailValidator` and session as singletons in DI
- add unit tests for `EmailValidator` and `UserSession`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855623007788320aa155fe75fe84931