### PR TITLE
Fix test reference and unify FluentValidation version

### DIFF
--- a/src/Publishing.Application/Publishing.Application.csproj
+++ b/src/Publishing.Application/Publishing.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="FluentValidation" Version="11.8.3" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Publishing.Core/Publishing.Core.csproj" />

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -19,5 +19,6 @@
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Application/Publishing.Application.csproj" />
+    <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- reference `Publishing.Services` from unit tests so namespaces resolve
- align FluentValidation dependency versions to 11.9.0

## Testing
- `dotnet build Publishing.sln` *(fails: command not found)*
- `dotnet test src/tests/Publishing.Core.Tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685565ae68508320b6e086c44dce026a