### PR TITLE
Fix tests on non-windows

### DIFF
--- a/src/Publishing.Services/Navigation/INavigationService.cs
+++ b/src/Publishing.Services/Navigation/INavigationService.cs
@@ -1,3 +1,4 @@
+#if WINDOWS
 namespace Publishing.Services
 {
     using System;
@@ -8,3 +9,4 @@ namespace Publishing.Services
         void Navigate<T>(Form current) where T : Form;
     }
 }
+#endif

--- a/src/Publishing.Services/Navigation/NavigationService.cs
+++ b/src/Publishing.Services/Navigation/NavigationService.cs
@@ -1,3 +1,4 @@
+#if WINDOWS
 namespace Publishing.Services
 {
     using System;
@@ -21,3 +22,4 @@ namespace Publishing.Services
         }
     }
 }
+#endif

--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWindowsForms>true</UseWindowsForms>
+    <TargetFrameworks>net6.0-windows;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <UseWindowsForms Condition="'$(TargetFramework)'=='net6.0-windows'">true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- allow Publishing.Services to build on non-Windows systems by cross-targeting
- compile NavigationService code only when building for Windows

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685566de86dc83209a3d716e899735b8