### PR TITLE
Fix email validation regex

### DIFF
--- a/src/Publishing.Application/Validators/EmailValidator.cs
+++ b/src/Publishing.Application/Validators/EmailValidator.cs
@@ -6,7 +6,10 @@ namespace Publishing.AppLayer.Validators
     {
         public EmailValidator()
         {
-            RuleFor(x => x).NotEmpty().EmailAddress();
+            RuleFor(x => x)
+                .NotEmpty()
+                // require domain part to contain a dot
+                .Matches(@"^[^@\s]+@[^@\s]+\.[^@\s]+$");
         }
     }
 }


### PR DESCRIPTION
## Summary
- tighten EmailValidator to ensure domains include a dot

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855680f9d788320aba5f9477dbba9f0