### PR TITLE
Log connection string

### DIFF
--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -78,6 +78,9 @@ namespace Publishing
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 
+            System.Diagnostics.Debug.WriteLine(
+                "Connection string: " + configuration.GetConnectionString("DefaultConnection"));
+
             services.AddSingleton<IConfiguration>(configuration);
             services.AddDbContext<AppDbContext>(o =>
                 o.UseSqlServer(


### PR DESCRIPTION
## Summary
- log the database connection string on startup

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556a3502c48320ac9845a7edcf92d9