### PR TITLE
Load design-time connection from config

### DIFF
--- a/src/Publishing.Infrastructure/DesignTimeDbContextFactory.cs
+++ b/src/Publishing.Infrastructure/DesignTimeDbContextFactory.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System.IO;
 
 namespace Publishing.Infrastructure
 {
@@ -7,10 +9,16 @@ namespace Publishing.Infrastructure
     {
         public AppDbContext CreateDbContext(string[] args)
         {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false)
+                .Build();
+
             var builder = new DbContextOptionsBuilder<AppDbContext>();
-            // Use local SQL Server for design-time services. Replace with actual connection if needed.
-            builder.UseSqlServer("Server=(localdb)\\MSSQLLocalDB;Database=Publishing;Trusted_Connection=True;",
+            builder.UseSqlServer(
+                configuration.GetConnectionString("DefaultConnection"),
                 b => b.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName));
+
             return new AppDbContext(builder.Options);
         }
     }

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -78,6 +78,9 @@ namespace Publishing
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 
+            System.Diagnostics.Debug.WriteLine(
+                "Connection string: " + configuration.GetConnectionString("DefaultConnection"));
+
             services.AddSingleton<IConfiguration>(configuration);
             services.AddDbContext<AppDbContext>(o =>
                 o.UseSqlServer(


### PR DESCRIPTION
## Summary
- read connection string from `appsettings.json` in `DesignTimeDbContextFactory`
- keep logging the connection string at startup

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556a3502c48320ac9845a7edcf92d9