### PR TITLE
Fix project references to FluentValidation

### DIFF
--- a/src/Publishing.Application/Publishing.Application.csproj
+++ b/src/Publishing.Application/Publishing.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="FluentValidation" Version="11.8.3" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Publishing.Core/Publishing.Core.csproj" />

--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add FluentValidation dependency to Publishing.Core
- update Publishing.Application to use the same version

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685577daddd48320994482f6f925b959