### PR TITLE
Fix PhoneFaxValidator missing using

### DIFF
--- a/src/Publishing.Application/Validators/PhoneFaxValidator.cs
+++ b/src/Publishing.Application/Validators/PhoneFaxValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using System.Linq;
 
 namespace Publishing.AppLayer.Validators
 {


### PR DESCRIPTION
## Summary
- ensure PhoneFaxValidator includes System.Linq

## Testing
- `dotnet build Publishing.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685580c341288320b46cc929beb71096