### PR TITLE
Fix RegistrationServiceTests compilation

### DIFF
--- a/src/tests/Publishing.Core.Tests/RegistrationServiceTests.cs
+++ b/src/tests/Publishing.Core.Tests/RegistrationServiceTests.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using Publishing.Core.DTOs;
 using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
+using Publishing.AppLayer.Validators;
 
 namespace Publishing.Core.Tests
 {
@@ -13,7 +14,7 @@ namespace Publishing.Core.Tests
         private class StubAuthService : IAuthService
         {
             public RegisterUserDto? Passed;
-            public UserDto ReturnUser = new UserDto { Id = "1", Name = "N", Type = "t" };
+            public UserDto ReturnUser = new UserDto("1", "N", "t");
 
             public Task<UserDto?> AuthenticateAsync(string email, string password)
                 => Task.FromResult<UserDto?>(null);


### PR DESCRIPTION
## Summary
- update `RegistrationServiceTests` to use validators namespace
- fix `UserDto` initialization with record constructor

## Testing
- `dotnet test --no-build -c Debug` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68558171ff008320b5fe70813c69d5f6