### PR TITLE
Allow connection string overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ All EF Core migration files must be compiled so `Database.MigrateAsync()` can lo
 </ItemGroup>
 ```
 
+### Custom Connection String
+
+`src/Publishing.UI/appsettings.json` defines `ConnectionStrings:DefaultConnection`. Update this value to point to a different SQL Server instance:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true"
+  }
+}
+```
+
+`Program.cs` also loads environment variables, so you can override the setting at runtime with `ConnectionStrings__DefaultConnection`.
+
 ## Working with migrations
 
 1. Install the EF Core tools if needed:

--- a/src/Publishing.Infrastructure/DesignTimeDbContextFactory.cs
+++ b/src/Publishing.Infrastructure/DesignTimeDbContextFactory.cs
@@ -14,6 +14,7 @@ namespace Publishing.Infrastructure
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(uiDir)
                 .AddJsonFile("appsettings.json", optional: false)
+                .AddEnvironmentVariables()
                 .Build();
 
             var builder = new DbContextOptionsBuilder<AppDbContext>();

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -78,6 +78,7 @@ namespace Publishing
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: false)
+                .AddEnvironmentVariables()
                 .Build();
 
             System.Diagnostics.Debug.WriteLine(


### PR DESCRIPTION
## Summary
- document how to change the connection string and override it with an environment variable
- enable environment variable configuration in `Program.cs`
- allow `dotnet ef` to pick up env vars via `DesignTimeDbContextFactory`

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68558393b1cc8320850c049c147d3959