### PR TITLE
Fix SSL connection failure by trusting SQL Server certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ All EF Core migration files must be compiled so `Database.MigrateAsync()` can lo
 
 ### Custom Connection String
 
-`src/Publishing.UI/appsettings.json` defines `ConnectionStrings:DefaultConnection`. Update this value to point to a different SQL Server instance:
+`src/Publishing.UI/appsettings.json` defines `ConnectionStrings:DefaultConnection`. Update this value to point to a different SQL Server instance. The default connection string now includes `TrustServerCertificate=True` to suppress SSL certificate warnings when using a self-signed SQL Server certificate:
 
 ```json
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true"
+    "DefaultConnection": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true;TrustServerCertificate=True"
   }
 }
 ```

--- a/src/Publishing.UI/appsettings.json
+++ b/src/Publishing.UI/appsettings.json
@@ -1,5 +1,5 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true"
+    "DefaultConnection": "Data Source=My-PC;Initial Catalog=Publishing;Integrated Security=true;TrustServerCertificate=True"
   }
 }


### PR DESCRIPTION
## Summary
- allow trusting SQL Server's certificate in the default connection string
- document the added setting in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558b6b0b6c8320a38b43987f1cb379