### PR TITLE
Fix initializer error when Person table exists

### DIFF
--- a/src/Publishing.Infrastructure/DatabaseInitializer.cs
+++ b/src/Publishing.Infrastructure/DatabaseInitializer.cs
@@ -14,9 +14,10 @@ namespace Publishing.Infrastructure
 
         public Task InitializeAsync()
         {
-            // Apply pending migrations if any exist. This keeps the database
-            // schema in sync with the current EF Core model.
-            return _context.Database.MigrateAsync();
+            // Use EnsureCreated so the initializer can run safely against an
+            // existing database. It creates the schema only if the tables are
+            // missing and is idempotent across multiple calls.
+            return _context.Database.EnsureCreatedAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid duplicate table errors by switching to `EnsureCreated`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68558c7c8e58832084f8e65684c862ef