### PR TITLE
Implement data-access query objects

### DIFF
--- a/Data-access conventions.md
+++ b/Data-access conventions.md
@@ -1,0 +1,35 @@
+# Data access conventions
+
+This document describes how query objects are implemented in this repository.
+
+## Query objects
+
+Every database query is represented by a class derived from `SqlQuery<T>` or `SqlCommand`. A query contains the SQL string, optional parameter object and a `Map` method for materialising a result row. Commands only provide the SQL and parameters.
+
+Example query:
+
+```csharp
+public sealed class GetActiveOrdersQuery : SqlQuery<Order>
+{
+    public override string Sql => "SELECT * FROM Orders";
+    public override Order Map(IDataReader reader) => new Order { /* mapping */ };
+}
+```
+
+Unit tests should verify that the SQL string of a query matches the expected statement.
+
+## Dispatchers
+
+`IQueryDispatcher` and `ICommandDispatcher` execute query objects using `IDbConnectionFactory`. They also emit OpenTelemetry activities and log executed SQL statements.
+
+## Logging and caching
+
+`LoggingDbConnection` wraps a real `DbConnection` and logs SQL text and execution time via `ILogger`. For rarely changing reference data queries a `MemoryCacheQueryDispatcher` decorator can be used:
+
+```csharp
+var cached = new MemoryCacheQueryDispatcher(inner, cache, TimeSpan.FromMinutes(10));
+```
+
+## Integration testing
+
+Integration tests spin up a SQL Server container with Testcontainers and execute the query objects against a real database to validate SQL syntax.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository hosts a simple publishing workflow demo. Database schema is main
 
 The `Publishing.UI` project contains an `appsettings.json` file with a default connection string pointing to LocalDB.  The project file copies this file to the output directory so both the application and `dotnet ef` commands can use it automatically. During startup a dedicated initializer applies pending EF Core migrations so the schema stays in sync with the models.
 
+See [Data-access conventions](Data-access conventions.md) for details on the Query Object pattern used for database access.
+
 All EF Core migration files must be compiled so `Database.MigrateAsync()` can locate them during integration tests. If the EF tools added them as `None` items, ensure they are built with:
 
 ```xml

--- a/src/Publishing.Infrastructure/DataAccess/CommandDispatcher.cs
+++ b/src/Publishing.Infrastructure/DataAccess/CommandDispatcher.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Publishing.Core.Interfaces;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class CommandDispatcher : ICommandDispatcher
+{
+    private readonly IDbConnectionFactory _factory;
+    private readonly ILogger _logger;
+    private readonly ActivitySource _activitySource = new("CommandDispatcher");
+
+    public CommandDispatcher(IDbConnectionFactory factory, ILogger logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task<int> ExecuteAsync(SqlCommand command, CancellationToken token = default)
+    {
+        using var activity = _activitySource.StartActivity(command.Sql);
+        using var con = await _factory.CreateOpenConnectionAsync();
+        var affected = await con.ExecuteAsync(new CommandDefinition(command.Sql, command.Parameters, cancellationToken: token));
+        _logger.LogInformation($"SQL: {command.Sql}; rows: {affected}");
+        return affected;
+    }
+}

--- a/src/Publishing.Infrastructure/DataAccess/DeleteOrderCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/DeleteOrderCommand.cs
@@ -1,0 +1,10 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class DeleteOrderCommand : SqlCommand
+{
+    public DeleteOrderCommand(int id) => Id = id;
+    public int Id { get; }
+
+    public override string Sql => "DELETE FROM Orders WHERE idOrder = @Id";
+    public override object Parameters => new { Id };
+}

--- a/src/Publishing.Infrastructure/DataAccess/GetActiveOrdersQuery.cs
+++ b/src/Publishing.Infrastructure/DataAccess/GetActiveOrdersQuery.cs
@@ -1,0 +1,28 @@
+using System.Data;
+using Publishing.Core.Domain;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class GetActiveOrdersQuery : SqlQuery<Order>
+{
+    public override string Sql =>
+        @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price
+          FROM (Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct)
+          INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder = 'в роботі' ORDER BY O.dateOrder";
+
+    public override Order Map(IDataReader reader)
+    {
+        return new Order
+        {
+            Printery = reader["namePrintery"].ToString() ?? string.Empty,
+            Type = reader["typeProduct"].ToString() ?? string.Empty,
+            Name = reader["nameProduct"].ToString() ?? string.Empty,
+            PersonId = string.Empty,
+            DateOrder = (DateTime)reader["dateOrder"],
+            DateStart = (DateTime)reader["dateStart"],
+            DateFinish = (DateTime)reader["dateFinish"],
+            Status = Enum.TryParse<OrderStatus>(reader["statusOrder"].ToString(), out var s) ? s : OrderStatus.InProgress,
+            Price = (decimal)reader["price"]
+        };
+    }
+}

--- a/src/Publishing.Infrastructure/DataAccess/ICommandDispatcher.cs
+++ b/src/Publishing.Infrastructure/DataAccess/ICommandDispatcher.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public interface ICommandDispatcher
+{
+    Task<int> ExecuteAsync(SqlCommand command, CancellationToken token = default);
+}

--- a/src/Publishing.Infrastructure/DataAccess/IQueryDispatcher.cs
+++ b/src/Publishing.Infrastructure/DataAccess/IQueryDispatcher.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public interface IQueryDispatcher
+{
+    Task<List<T>> QueryAsync<T>(SqlQuery<T> query, CancellationToken token = default);
+    Task<T?> QuerySingleAsync<T>(SqlQuery<T> query, CancellationToken token = default);
+}

--- a/src/Publishing.Infrastructure/DataAccess/InsertOrderCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/InsertOrderCommand.cs
@@ -1,0 +1,41 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class InsertOrderCommand : SqlCommand
+{
+    public InsertOrderCommand(int productId, string personId, string printery, DateTime start, DateTime finish, string status, int tirage, decimal price)
+    {
+        ProductId = productId;
+        PersonId = personId;
+        Printery = printery;
+        DateStart = start;
+        DateFinish = finish;
+        Status = status;
+        Tirage = tirage;
+        Price = price;
+    }
+
+    public int ProductId { get; }
+    public string PersonId { get; }
+    public string Printery { get; }
+    public DateTime DateStart { get; }
+    public DateTime DateFinish { get; }
+    public string Status { get; }
+    public int Tirage { get; }
+    public decimal Price { get; }
+
+    public override string Sql =>
+        @"INSERT INTO Orders(idProduct,idPerson,namePrintery,dateOrder,dateStart,dateFinish,statusOrder,tirage,price)
+          VALUES(@ProductId,@PersonId,@Printery,GETDATE(),@DateStart,@DateFinish,@Status,@Tirage,@Price)";
+
+    public override object Parameters => new
+    {
+        ProductId,
+        PersonId,
+        Printery,
+        DateStart,
+        DateFinish,
+        Status,
+        Tirage,
+        Price
+    };
+}

--- a/src/Publishing.Infrastructure/DataAccess/InsertOrganizationCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/InsertOrganizationCommand.cs
@@ -1,0 +1,26 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class InsertOrganizationCommand : SqlCommand
+{
+    public InsertOrganizationCommand(string name, string email, string phone, string fax, string address, string personId)
+    {
+        Name = name;
+        Email = email;
+        Phone = phone;
+        Fax = fax;
+        Address = address;
+        PersonId = personId;
+    }
+
+    public string Name { get; }
+    public string Email { get; }
+    public string Phone { get; }
+    public string Fax { get; }
+    public string Address { get; }
+    public string PersonId { get; }
+
+    public override string Sql =>
+        "INSERT INTO Organization(nameOrganization, emailOrganization, phoneOrganization, faxOrganization, addressOrganization, idPerson) VALUES (@Name, @Email, @Phone, @Fax, @Address, @PersonId)";
+
+    public override object Parameters => new { Name, Email, Phone, Fax, Address, PersonId };
+}

--- a/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
+++ b/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
@@ -1,0 +1,85 @@
+using System.Data.Common;
+using Publishing.Core.Interfaces;
+using System.Diagnostics;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public class LoggingDbConnection : DbConnection
+{
+    private readonly DbConnection _inner;
+    private readonly ILogger _logger;
+
+    public LoggingDbConnection(DbConnection inner, ILogger logger)
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    protected override DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel) => _inner.BeginTransaction(isolationLevel);
+    public override void Close() => _inner.Close();
+    public override void ChangeDatabase(string databaseName) => _inner.ChangeDatabase(databaseName);
+    public override string ConnectionString { get => _inner.ConnectionString; set => _inner.ConnectionString = value; }
+    public override string Database => _inner.Database;
+    public override string DataSource => _inner.DataSource;
+    public override string ServerVersion => _inner.ServerVersion;
+    public override System.Data.ConnectionState State => _inner.State;
+    public override void Open() => _inner.Open();
+
+    protected override DbCommand CreateDbCommand() => new LoggingDbCommand(_inner.CreateCommand(), _logger);
+}
+
+internal class LoggingDbCommand : DbCommand
+{
+    private readonly DbCommand _inner;
+    private readonly ILogger _logger;
+
+    public LoggingDbCommand(DbCommand inner, ILogger logger)
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    public override string CommandText { get => _inner.CommandText; set => _inner.CommandText = value; }
+    public override int CommandTimeout { get => _inner.CommandTimeout; set => _inner.CommandTimeout = value; }
+    public override System.Data.CommandType CommandType { get => _inner.CommandType; set => _inner.CommandType = value; }
+    public override bool DesignTimeVisible { get => _inner.DesignTimeVisible; set => _inner.DesignTimeVisible = value; }
+    public override UpdateRowSource UpdatedRowSource { get => _inner.UpdatedRowSource; set => _inner.UpdatedRowSource = value; }
+    protected override DbConnection DbConnection { get => _inner.Connection!; set => _inner.Connection = value; }
+    protected override DbParameterCollection DbParameterCollection => _inner.Parameters;
+    protected override DbTransaction DbTransaction { get => _inner.Transaction!; set => _inner.Transaction = value; }
+    public override void Cancel() => _inner.Cancel();
+
+    protected override DbParameter CreateDbParameter() => _inner.CreateParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior)
+    {
+        _logger.LogInformation($"SQL: {CommandText}");
+        var sw = Stopwatch.StartNew();
+        var reader = _inner.ExecuteReader(behavior);
+        sw.Stop();
+        _logger.LogInformation($"Elapsed {sw.ElapsedMilliseconds} ms");
+        return reader;
+    }
+
+    public override int ExecuteNonQuery()
+    {
+        _logger.LogInformation($"SQL: {CommandText}");
+        var sw = Stopwatch.StartNew();
+        var result = _inner.ExecuteNonQuery();
+        sw.Stop();
+        _logger.LogInformation($"Affected {result} rows in {sw.ElapsedMilliseconds} ms");
+        return result;
+    }
+
+    public override object ExecuteScalar()
+    {
+        _logger.LogInformation($"SQL: {CommandText}");
+        var sw = Stopwatch.StartNew();
+        var result = _inner.ExecuteScalar();
+        sw.Stop();
+        _logger.LogInformation($"Elapsed {sw.ElapsedMilliseconds} ms");
+        return result!;
+    }
+
+    public override void Prepare() => _inner.Prepare();
+}

--- a/src/Publishing.Infrastructure/DataAccess/MemoryCacheQueryDispatcher.cs
+++ b/src/Publishing.Infrastructure/DataAccess/MemoryCacheQueryDispatcher.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class MemoryCacheQueryDispatcher : IQueryDispatcher
+{
+    private readonly IQueryDispatcher _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public MemoryCacheQueryDispatcher(IQueryDispatcher inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<List<T>> QueryAsync<T>(SqlQuery<T> query, CancellationToken token = default)
+    {
+        var key = $"sql:{query.Sql}:{query.Parameters}";
+        if (_cache.TryGetValue(key, out List<T> cached))
+            return cached;
+        var result = await _inner.QueryAsync(query, token);
+        _cache.Set(key, result, _ttl);
+        return result;
+    }
+
+    public async Task<T?> QuerySingleAsync<T>(SqlQuery<T> query, CancellationToken token = default)
+    {
+        var list = await QueryAsync(query, token);
+        return list.Count > 0 ? list[0] : default;
+    }
+}

--- a/src/Publishing.Infrastructure/DataAccess/QueryDispatcher.cs
+++ b/src/Publishing.Infrastructure/DataAccess/QueryDispatcher.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Publishing.Core.Interfaces;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class QueryDispatcher : IQueryDispatcher
+{
+    private readonly IDbConnectionFactory _factory;
+    private readonly ILogger _logger;
+    private readonly ActivitySource _activitySource = new("QueryDispatcher");
+
+    public QueryDispatcher(IDbConnectionFactory factory, ILogger logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task<List<T>> QueryAsync<T>(SqlQuery<T> query, CancellationToken token = default)
+    {
+        using var activity = _activitySource.StartActivity(query.Sql);
+        using var con = await _factory.CreateOpenConnectionAsync();
+        var list = new List<T>();
+        using var reader = await con.ExecuteReaderAsync(new CommandDefinition(query.Sql, query.Parameters, cancellationToken: token));
+        while (reader.Read())
+        {
+            list.Add(query.Map(reader));
+        }
+        _logger.LogInformation($"SQL: {query.Sql}; rows: {list.Count}");
+        return list;
+    }
+
+    public async Task<T?> QuerySingleAsync<T>(SqlQuery<T> query, CancellationToken token = default)
+    {
+        var list = await QueryAsync(query, token);
+        return list.Count > 0 ? list[0] : default;
+    }
+}

--- a/src/Publishing.Infrastructure/DataAccess/SqlCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/SqlCommand.cs
@@ -1,0 +1,13 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+/// <summary>
+/// Base class for command objects which modify data.
+/// </summary>
+public abstract class SqlCommand
+{
+    /// <summary>SQL statement to execute.</summary>
+    public abstract string Sql { get; }
+
+    /// <summary>Parameters object for the statement.</summary>
+    public virtual object? Parameters => null;
+}

--- a/src/Publishing.Infrastructure/DataAccess/SqlQuery.cs
+++ b/src/Publishing.Infrastructure/DataAccess/SqlQuery.cs
@@ -1,0 +1,18 @@
+using System.Data;
+
+namespace Publishing.Infrastructure.DataAccess;
+
+/// <summary>
+/// Base class for query objects returning <typeparamref name="T"/>.
+/// </summary>
+public abstract class SqlQuery<T>
+{
+    /// <summary>SQL statement to execute.</summary>
+    public abstract string Sql { get; }
+
+    /// <summary>Parameters object for the statement.</summary>
+    public virtual object? Parameters => null;
+
+    /// <summary>Maps a row from <see cref="IDataReader"/> to the result type.</summary>
+    public abstract T Map(IDataReader reader);
+}

--- a/src/Publishing.Infrastructure/DataAccess/UpdateOrganizationCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/UpdateOrganizationCommand.cs
@@ -1,0 +1,26 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class UpdateOrganizationCommand : SqlCommand
+{
+    public UpdateOrganizationCommand(string id, string? name, string? email, string? phone, string? fax, string? address)
+    {
+        Id = id; Name = name; Email = email; Phone = phone; Fax = fax; Address = address;
+    }
+
+    public string Id { get; }
+    public string? Name { get; }
+    public string? Email { get; }
+    public string? Phone { get; }
+    public string? Fax { get; }
+    public string? Address { get; }
+
+    public override string Sql => @"UPDATE Organization SET
+        nameOrganization = ISNULL(@Name,nameOrganization),
+        emailOrganization = ISNULL(@Email,emailOrganization),
+        phoneOrganization = ISNULL(@Phone,phoneOrganization),
+        faxOrganization = ISNULL(@Fax,faxOrganization),
+        addressOrganization = ISNULL(@Address,addressOrganization)
+        WHERE idPerson = @Id";
+
+    public override object Parameters => new { Id, Name, Email, Phone, Fax, Address };
+}

--- a/src/Publishing.Infrastructure/DataAccess/UpdateProfileCommand.cs
+++ b/src/Publishing.Infrastructure/DataAccess/UpdateProfileCommand.cs
@@ -1,0 +1,30 @@
+namespace Publishing.Infrastructure.DataAccess;
+
+public sealed class UpdateProfileCommand : SqlCommand
+{
+    public UpdateProfileCommand(string id, string? fName, string? lName, string? email, string? status, string? phone, string? fax, string? address)
+    {
+        Id = id; FName = fName; LName = lName; Email = email; Status = status; Phone = phone; Fax = fax; Address = address;
+    }
+
+    public string Id { get; }
+    public string? FName { get; }
+    public string? LName { get; }
+    public string? Email { get; }
+    public string? Status { get; }
+    public string? Phone { get; }
+    public string? Fax { get; }
+    public string? Address { get; }
+
+    public override string Sql => @"UPDATE Person SET
+        FName = ISNULL(@FName,FName),
+        LName = ISNULL(@LName,LName),
+        emailPerson = ISNULL(@Email,emailPerson),
+        typePerson = ISNULL(@Status,typePerson),
+        phonePerson = ISNULL(@Phone,phonePerson),
+        faxPerson = ISNULL(@Fax,faxPerson),
+        addressPerson = ISNULL(@Address,addressPerson)
+        WHERE idPerson = @Id";
+
+    public override object Parameters => new { Id, FName, LName, Email, Status, Phone, Fax, Address };
+}

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.22">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
   </ItemGroup>
 
   <!-- Ensure EF Core migrations are compiled into the assembly -->

--- a/src/Publishing.Infrastructure/Repositories/LoginRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/LoginRepository.cs
@@ -6,6 +6,7 @@ using Publishing.Core.Interfaces;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class LoginRepository : ILoginRepository
     {
         private readonly IDbContext _db;

--- a/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
@@ -6,6 +6,7 @@ using Dapper;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class OrderRepository : IOrderRepository, IOrderQueries
     {
         private readonly IDbContext _db;

--- a/src/Publishing.Infrastructure/Repositories/OrganizationRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/OrganizationRepository.cs
@@ -6,6 +6,7 @@ using Publishing.Core.Interfaces;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class OrganizationRepository : IOrganizationRepository
     {
         private readonly IDbContext _db;

--- a/src/Publishing.Infrastructure/Repositories/PrinteryRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/PrinteryRepository.cs
@@ -2,6 +2,7 @@ using Publishing.Core.Interfaces;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class PrinteryRepository : IPrinteryRepository
     {
         public decimal GetPricePerPage() => 2.5m;

--- a/src/Publishing.Infrastructure/Repositories/ProfileRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/ProfileRepository.cs
@@ -6,6 +6,7 @@ using Publishing.Core.Interfaces;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class ProfileRepository : IProfileRepository
     {
         private readonly IDbContext _db;

--- a/src/Publishing.Infrastructure/Repositories/StatisticRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/StatisticRepository.cs
@@ -5,6 +5,7 @@ using Publishing.Core.Interfaces;
 
 namespace Publishing.Infrastructure.Repositories
 {
+    [Obsolete("Replaced by query objects")]
     public class StatisticRepository : IStatisticRepository
     {
         private readonly IDbHelper _helper;

--- a/src/Publishing.Infrastructure/SqlDbConnectionFactory.cs
+++ b/src/Publishing.Infrastructure/SqlDbConnectionFactory.cs
@@ -2,23 +2,26 @@ using System.Data;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Publishing.Core.Interfaces;
+using Publishing.Infrastructure.DataAccess;
 
 namespace Publishing.Infrastructure
 {
     public class SqlDbConnectionFactory : IDbConnectionFactory
     {
         private readonly string _connectionString;
+        private readonly ILogger _logger;
 
-        public SqlDbConnectionFactory(IConfiguration configuration)
+        public SqlDbConnectionFactory(IConfiguration configuration, ILogger logger)
         {
             _connectionString = configuration.GetConnectionString("DefaultConnection")!;
+            _logger = logger;
         }
 
         public async Task<IDbConnection> CreateOpenConnectionAsync()
         {
             var connection = new SqlConnection(_connectionString);
             await connection.OpenAsync();
-            return connection;
+            return new LoggingDbConnection(connection, _logger);
         }
     }
 }

--- a/src/tests/Publishing.Core.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Core.Tests/SqlQueryTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Infrastructure.DataAccess;
+using Publishing.Core.Domain;
+using System.Data;
+
+namespace Publishing.Core.Tests;
+
+[TestClass]
+public class SqlQueryTests
+{
+    [TestMethod]
+    public void GetActiveOrdersQuery_HasExpectedSql()
+    {
+        var query = new GetActiveOrdersQuery();
+        StringAssert.Contains(query.Sql, "SELECT");
+    }
+}

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.22">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="DotNet.Testcontainers" Version="3.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />

--- a/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
@@ -1,0 +1,131 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Infrastructure.DataAccess;
+using Publishing.Infrastructure;
+using Publishing.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Caching.Memory;
+using System.Threading.Tasks;
+using System.Data;
+using Dapper;
+using System.Linq;
+using System.Threading;
+using System.Collections.Generic;
+
+namespace Publishing.Integration.Tests;
+
+[TestClass]
+public class SqlQueryTests
+{
+    private TestcontainerDatabase _dbContainer = null!;
+    private ServiceProvider _sp = null!;
+
+    [TestInitialize]
+    public async Task Init()
+    {
+        _dbContainer = new TestcontainersBuilder<MsSqlTestcontainer>()
+            .WithDatabase(new MsSqlTestcontainerConfiguration())
+            .Build();
+        await _dbContainer.StartAsync();
+
+        var services = new ServiceCollection();
+        services.AddTransient<ILogger, LoggerService>();
+        services.AddSingleton<IDbConnectionFactory>(sp =>
+            new SqlDbConnectionFactory(new TestConfiguration(_dbContainer.ConnectionString), sp.GetRequiredService<ILogger>()));
+        services.AddTransient<IDbContext, DapperDbContext>();
+        services.AddMemoryCache();
+        services.AddSingleton<QueryDispatcher>();
+        services.AddSingleton<IQueryDispatcher>(sp =>
+            new MemoryCacheQueryDispatcher(
+                sp.GetRequiredService<QueryDispatcher>(),
+                sp.GetRequiredService<IMemoryCache>(),
+                TimeSpan.FromMinutes(10)));
+        services.AddSingleton<ICommandDispatcher, CommandDispatcher>();
+        _sp = services.BuildServiceProvider();
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        if (_sp != null) _sp.Dispose();
+        if (_dbContainer != null) await _dbContainer.StopAsync();
+    }
+
+    [TestMethod]
+    public async Task Execute_InsertAndSelect_Works()
+    {
+        using var scope = _sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbConnectionFactory>();
+        using var con = await factory.CreateOpenConnectionAsync();
+        await con.ExecuteAsync("CREATE TABLE Sample(id INT PRIMARY KEY, val INT)");
+        var cmdDispatcher = scope.ServiceProvider.GetRequiredService<ICommandDispatcher>();
+        await cmdDispatcher.ExecuteAsync(new RawSqlCommand("INSERT INTO Sample(id,val) VALUES(1,42)"));
+        var queryDispatcher = scope.ServiceProvider.GetRequiredService<IQueryDispatcher>();
+        var result = await queryDispatcher.QuerySingleAsync(new RawScalarQuery<int>("SELECT val FROM Sample WHERE id=1"));
+        Assert.AreEqual(42, result);
+    }
+
+    [TestMethod]
+    public async Task Execute_UpdateAndSelect_Works()
+    {
+        using var scope = _sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbConnectionFactory>();
+        using var con = await factory.CreateOpenConnectionAsync();
+        await con.ExecuteAsync("CREATE TABLE Sample(id INT PRIMARY KEY, val INT)");
+        var cmdDispatcher = scope.ServiceProvider.GetRequiredService<ICommandDispatcher>();
+        await cmdDispatcher.ExecuteAsync(new RawSqlCommand("INSERT INTO Sample(id,val) VALUES(1,42)"));
+        await cmdDispatcher.ExecuteAsync(new RawSqlCommand("UPDATE Sample SET val=99 WHERE id=1"));
+        var queryDispatcher = scope.ServiceProvider.GetRequiredService<IQueryDispatcher>();
+        var result = await queryDispatcher.QuerySingleAsync(new RawScalarQuery<int>("SELECT val FROM Sample WHERE id=1"));
+        Assert.AreEqual(99, result);
+    }
+
+    [TestMethod]
+    public async Task Execute_DeleteAndCount_Works()
+    {
+        using var scope = _sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbConnectionFactory>();
+        using var con = await factory.CreateOpenConnectionAsync();
+        await con.ExecuteAsync("CREATE TABLE Sample(id INT PRIMARY KEY, val INT)");
+        var cmdDispatcher = scope.ServiceProvider.GetRequiredService<ICommandDispatcher>();
+        await cmdDispatcher.ExecuteAsync(new RawSqlCommand("INSERT INTO Sample(id,val) VALUES(1,42)"));
+        await cmdDispatcher.ExecuteAsync(new RawSqlCommand("DELETE FROM Sample WHERE id=1"));
+        var queryDispatcher = scope.ServiceProvider.GetRequiredService<IQueryDispatcher>();
+        var count = await queryDispatcher.QuerySingleAsync(new RawScalarQuery<int>("SELECT COUNT(*) FROM Sample"));
+        Assert.AreEqual(0, count);
+    }
+
+    private record RawSqlCommand(string SqlText) : SqlCommand
+    {
+        public override string Sql => SqlText;
+    }
+
+    private record RawScalarQuery<T>(string SqlText) : SqlQuery<T>
+    {
+        public override string Sql => SqlText;
+        public override T Map(IDataReader reader) => (T)reader.GetValue(0);
+    }
+
+    private class TestConfiguration : Microsoft.Extensions.Configuration.IConfiguration
+    {
+        private readonly string _cs;
+        public TestConfiguration(string cs) { _cs = cs; }
+        public string? this[string key] { get => key == "ConnectionStrings:DefaultConnection" ? _cs : null; set { } }
+        public IEnumerable<IConfigurationSection> GetChildren() => Enumerable.Empty<IConfigurationSection>();
+        public IChangeToken GetReloadToken() => new Microsoft.Extensions.Primitives.CancellationChangeToken(new CancellationTokenSource().Token);
+        public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
+        private class ConfigurationSection : IConfigurationSection
+        {
+            private readonly IConfiguration _cfg; private readonly string _key;
+            public ConfigurationSection(IConfiguration cfg, string key){_cfg=cfg;_key=key;}
+            public string Key => _key; public string Path => _key; public string? Value {get=>_cfg[_key];set{}}
+            public string this[string key] { get => _cfg[$"{_key}:{key}"]!; set { } }
+            public IEnumerable<IConfigurationSection> GetChildren() => Enumerable.Empty<IConfigurationSection>();
+            public IChangeToken GetReloadToken() => _cfg.GetReloadToken();
+            public IConfigurationSection GetSection(string key) => new ConfigurationSection(_cfg,$"{_key}:{key}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `LoggingDbConnection` via `SqlDbConnectionFactory`
- register query/command dispatchers with memory cache
- mark old repositories obsolete
- include link to data-access conventions in README
- expand integration tests with update & delete cases

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558eca7f808320acc64191e5de6ea0