### PR TITLE
Fix build issue in LoggingDbConnection

### DIFF
--- a/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
+++ b/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Data;
 using Publishing.Core.Interfaces;
 using System.Diagnostics;
 


### PR DESCRIPTION
## Summary
- fix missing `System.Data` import

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685593b3716c83209218fd8ba1332238