### PR TITLE
Fix build by adding DateOrder property

### DIFF
--- a/src/Publishing.Core/Domain/Order.cs
+++ b/src/Publishing.Core/Domain/Order.cs
@@ -8,6 +8,7 @@ namespace Publishing.Core.Domain
         public string Name { get; set; } = string.Empty;
         public int Pages { get; set; }
         public int Tirage { get; set; }
+        public DateTime DateOrder { get; set; }
         public DateTime DateStart { get; set; }
         public DateTime DateFinish { get; set; }
         public OrderStatus Status { get; set; } = OrderStatus.InProgress;


### PR DESCRIPTION
## Summary
- add `DateOrder` property to the domain `Order`

## Testing
- `dotnet test --no-build src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855942b3f008320bfaf52c7fd7807ca