### PR TITLE
Fix missing using directives

### DIFF
--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -11,6 +11,8 @@ using Publishing.Core.Services;
 using Publishing.Infrastructure;
 using Publishing.Infrastructure.Repositories;
 using Publishing.Infrastructure.DataAccess;
+using Publishing.Infrastructure.Queries;
+using Microsoft.Extensions.Caching.Memory;
 using MediatR;
 using Publishing.AppLayer.Handlers;
 using Publishing.AppLayer.Validators;


### PR DESCRIPTION
## Summary
- add missing `OrderQueries` and `IMemoryCache` namespaces in `Publishing.UI`

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68559512cdb483209922d3db9864b45e