### PR TITLE
Fix nuget restore error

### DIFF
--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.22">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DotNet.Testcontainers" Version="3.8.0" />
+    <PackageReference Include="DotNet.Testcontainers" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />


### PR DESCRIPTION
## Summary
- fix testcontainers package version so `dotnet restore` can succeed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559627447c8320b2615314d52a3bd0