### PR TITLE
Fix integration tests build without Testcontainers

### DIFF
--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.22">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />


### PR DESCRIPTION
## Summary
- remove DotNet.Testcontainers package reference
- use LocalDB in `SqlQueryTests` instead of Testcontainers

## Testing
- `dotnet restore` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685598230db4832094d7d078d6bfa1da