### PR TITLE
Fix integration tests compile errors

### DIFF
--- a/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
@@ -119,13 +119,17 @@ END";
         Assert.AreEqual(0, count);
     }
 
-    private record RawSqlCommand(string SqlText) : SqlCommand
+    private class RawSqlCommand : Publishing.Infrastructure.DataAccess.SqlCommand
     {
+        public RawSqlCommand(string sqlText) { SqlText = sqlText; }
+        private string SqlText { get; }
         public override string Sql => SqlText;
     }
 
-    private record RawScalarQuery<T>(string SqlText) : SqlQuery<T>
+    private class RawScalarQuery<T> : Publishing.Infrastructure.DataAccess.SqlQuery<T>
     {
+        public RawScalarQuery(string sqlText) { SqlText = sqlText; }
+        private string SqlText { get; }
         public override string Sql => SqlText;
         public override T Map(IDataReader reader) => (T)reader.GetValue(0);
     }


### PR DESCRIPTION
## Summary
- fix ambiguous base class in `SqlQueryTests`
- convert helper records to classes to avoid record inheritance errors

## Testing
- `dotnet build Publishing.sln -c Debug` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855995a93d08320bd21d3897578d2f8