### PR TITLE
Fix missing namespace in SqlQueryTests

### DIFF
--- a/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Threading;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
+using System;
 
 namespace Publishing.Integration.Tests;
 


### PR DESCRIPTION
## Summary
- fix missing System namespace in `SqlQueryTests`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68559a14826c83209807fa766b182565