### PR TITLE
Fix missing using directive for Sqlite connection factory

### DIFF
--- a/src/tests/Publishing.Integration.Tests/SqliteDbConnectionFactory.cs
+++ b/src/tests/Publishing.Integration.Tests/SqliteDbConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Publishing.Core.Interfaces;


### PR DESCRIPTION
## Summary
- add a Task namespace import in the Sqlite test connection factory

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559e0e4f3083209401a29dae804021