### PR TITLE
Fix integration test db files and casting

### DIFF
--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -20,8 +20,8 @@ namespace Publishing.Integration.Tests
     [TestClass]
     public class CrudFlowTests
     {
-        private static readonly string DbPath = Path.Combine(Path.GetTempPath(), "PublishingCrud.db");
-        private static string ConnectionString => $"Data Source={DbPath}";
+        private string _dbPath = null!;
+        private string ConnectionString => $"Data Source={_dbPath}";
 
         private IDbContext _db = null!;
         private ServiceProvider _serviceProvider = null!;
@@ -29,9 +29,10 @@ namespace Publishing.Integration.Tests
         [TestInitialize]
         public void Setup()
         {
-            if (File.Exists(DbPath))
+            _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingCrud_{Guid.NewGuid()}.db");
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
             var cs = ConnectionString;
             var config = new ConfigurationBuilder()
@@ -63,9 +64,9 @@ namespace Publishing.Integration.Tests
             {
                 _serviceProvider.Dispose();
             }
-            if (File.Exists(DbPath))
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
         }
 

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -17,8 +17,8 @@ namespace Publishing.Integration.Tests
     [TestClass]
     public class DataBaseIntegrationTests
     {
-        private static readonly string DbPath = Path.Combine(Path.GetTempPath(), "PublishingTest.db");
-        private static string ConnectionString => $"Data Source={DbPath}";
+        private string _dbPath = null!;
+        private string ConnectionString => $"Data Source={_dbPath}";
 
         private IDbContext _db = null!;
         private IDbHelper _helper = null!;
@@ -27,9 +27,10 @@ namespace Publishing.Integration.Tests
         [TestInitialize]
         public void Setup()
         {
-            if (File.Exists(DbPath))
+            _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingTest_{Guid.NewGuid()}.db");
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
             var cs = ConnectionString;
             var config = new ConfigurationBuilder()
@@ -64,9 +65,9 @@ namespace Publishing.Integration.Tests
             {
                 _serviceProvider.Dispose();
             }
-            if (File.Exists(DbPath))
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
         }
 

--- a/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
@@ -21,18 +21,19 @@ namespace Publishing.Integration.Tests;
 [TestClass]
 public class SqlQueryTests
 {
-    private static readonly string DbPath = Path.Combine(Path.GetTempPath(), "SqlQueryTest.db");
+    private string _dbPath = null!;
     private ServiceProvider _sp = null!;
     private string _cs = null!;
 
     [TestInitialize]
     public void Init()
     {
-        if (File.Exists(DbPath))
+        _dbPath = Path.Combine(Path.GetTempPath(), $"SqlQueryTest_{Guid.NewGuid()}.db");
+        if (File.Exists(_dbPath))
         {
-            File.Delete(DbPath);
+            File.Delete(_dbPath);
         }
-        _cs = $"Data Source={DbPath}";
+        _cs = $"Data Source={_dbPath}";
 
         var services = new ServiceCollection();
         services.AddTransient<ILogger, LoggerService>();
@@ -54,9 +55,9 @@ public class SqlQueryTests
     public void Cleanup()
     {
         if (_sp != null) _sp.Dispose();
-        if (File.Exists(DbPath))
+        if (File.Exists(_dbPath))
         {
-            File.Delete(DbPath);
+            File.Delete(_dbPath);
         }
     }
 
@@ -116,7 +117,7 @@ public class SqlQueryTests
         public RawScalarQuery(string sqlText) { SqlText = sqlText; }
         private string SqlText { get; }
         public override string Sql => SqlText;
-        public override T Map(IDataReader reader) => (T)reader.GetValue(0);
+        public override T Map(IDataReader reader) => (T)Convert.ChangeType(reader.GetValue(0), typeof(T));
     }
 
     private class TestConfiguration : Microsoft.Extensions.Configuration.IConfiguration

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -15,8 +15,8 @@ namespace Publishing.Integration.Tests
     [TestClass]
     public class StatisticTests
     {
-        private static readonly string DbPath = Path.Combine(Path.GetTempPath(), "PublishingStat.db");
-        private static string ConnectionString => $"Data Source={DbPath}";
+        private string _dbPath = null!;
+        private string ConnectionString => $"Data Source={_dbPath}";
 
         private IDbContext _db = null!;
         private IDbHelper _helper = null!;
@@ -25,9 +25,10 @@ namespace Publishing.Integration.Tests
         [TestInitialize]
         public void Setup()
         {
-            if (File.Exists(DbPath))
+            _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingStat_{Guid.NewGuid()}.db");
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
             var cs = ConnectionString;
             var config = new ConfigurationBuilder()
@@ -66,9 +67,9 @@ namespace Publishing.Integration.Tests
             {
                 _serviceProvider.Dispose();
             }
-            if (File.Exists(DbPath))
+            if (File.Exists(_dbPath))
             {
-                File.Delete(DbPath);
+                File.Delete(_dbPath);
             }
         }
 


### PR DESCRIPTION
## Summary
- use unique SQLite database files per integration test
- correct scalar query type conversion in SqlQueryTests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a29261ec8320a1129fb934eb16d4