### PR TITLE
Fix SQLite file locks in integration tests

### DIFF
--- a/src/tests/Publishing.Integration.Tests/SqliteDbConnectionFactory.cs
+++ b/src/tests/Publishing.Integration.Tests/SqliteDbConnectionFactory.cs
@@ -15,7 +15,12 @@ public class SqliteDbConnectionFactory : IDbConnectionFactory
 
     public SqliteDbConnectionFactory(IConfiguration configuration, ILogger logger)
     {
-        _connectionString = configuration.GetConnectionString("DefaultConnection")!;
+        var cs = configuration.GetConnectionString("DefaultConnection")!;
+        var builder = new SqliteConnectionStringBuilder(cs)
+        {
+            Pooling = false
+        };
+        _connectionString = builder.ToString();
         _logger = logger;
     }
 


### PR DESCRIPTION
## Summary
- disable connection pooling in SQLite integration tests to ensure temporary files can be deleted

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a564f71c83209735061b2a5d706e