### PR TITLE
Fix connection disposal

### DIFF
--- a/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
+++ b/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
@@ -26,6 +26,15 @@ public class LoggingDbConnection : DbConnection
     public override System.Data.ConnectionState State => _inner.State;
     public override void Open() => _inner.Open();
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
     protected override DbCommand CreateDbCommand() => new LoggingDbCommand(_inner.CreateCommand(), _logger);
 }
 


### PR DESCRIPTION
## Summary
- ensure LoggingDbConnection disposes wrapped connection

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a6854a6483209eebb2ec1266628d