### PR TITLE
Fix connection disposal

### DIFF
--- a/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
+++ b/src/Publishing.Infrastructure/DataAccess/LoggingDbConnection.cs
@@ -26,6 +26,15 @@ public class LoggingDbConnection : DbConnection
     public override System.Data.ConnectionState State => _inner.State;
     public override void Open() => _inner.Open();
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
     protected override DbCommand CreateDbCommand() => new LoggingDbCommand(_inner.CreateCommand(), _logger);
 }
 

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -34,7 +34,11 @@ namespace Publishing.Integration.Tests
             {
                 File.Delete(_dbPath);
             }
-            var cs = ConnectionString;
+            var builder = new SqliteConnectionStringBuilder(ConnectionString)
+            {
+                Pooling = false
+            };
+            var cs = builder.ToString();
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -32,7 +32,11 @@ namespace Publishing.Integration.Tests
             {
                 File.Delete(_dbPath);
             }
-            var cs = ConnectionString;
+            var builder = new SqliteConnectionStringBuilder(ConnectionString)
+            {
+                Pooling = false
+            };
+            var cs = builder.ToString();
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -30,7 +30,11 @@ namespace Publishing.Integration.Tests
             {
                 File.Delete(_dbPath);
             }
-            var cs = ConnectionString;
+            var builder = new SqliteConnectionStringBuilder(ConnectionString)
+            {
+                Pooling = false
+            };
+            var cs = builder.ToString();
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {


### PR DESCRIPTION
## Summary
- ensure LoggingDbConnection disposes wrapped connection
- disable SQLite pooling in integration tests so database files aren't locked

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a6854a6483209eebb2ec1266628d