### PR TITLE
Fix crash on invalid order submission

### DIFF
--- a/src/Publishing.UI/Forms/addOrderForm.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.cs
@@ -6,6 +6,8 @@ using Publishing.Services;
 using MediatR;
 using Publishing.AppLayer.Commands;
 using System.Resources;
+using FluentValidation;
+using System.Linq;
 
 namespace Publishing
 {
@@ -119,12 +121,23 @@ namespace Publishing
             };
 
             var command = new CreateOrderCommand(dto.Type, dto.Name, dto.Pages, dto.Tirage, dto.PersonId, dto.Printery);
-            var order = await _mediator.Send(command);
+            try
+            {
+                var order = await _mediator.Send(command);
 
-            MessageBox.Show(_resources.GetString("OrderAdded") ?? "Success");
-            totalPriceLabel.Text = "Кінцева ціна:" + order.Price.ToString();
+                MessageBox.Show(_resources.GetString("OrderAdded") ?? "Success");
+                totalPriceLabel.Text = "Кінцева ціна:" + order.Price.ToString();
 
-            _navigation.Navigate<mainForm>(this);
+                _navigation.Navigate<mainForm>(this);
+            }
+            catch (ValidationException ex)
+            {
+                MessageBox.Show(string.Join("\n", ex.Errors.Select(e => e.ErrorMessage)), "Validation error");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+            }
         }
 
         private void змінитиДаніToolStripMenuItem_Click_1(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- catch validation errors when submitting an order

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855d15a08708320a1ce61cb328c546f