### PR TITLE
Fix resource manager base name

### DIFF
--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -12,7 +12,7 @@ namespace Publishing
         private readonly INavigationService _navigation;
         private readonly IOrganizationService _service;
         private readonly IUserSession _session;
-        private readonly ResourceManager _resources = new ResourceManager("Publishing.UI.Resources.Resources", typeof(organizationForm).Assembly);
+        private readonly ResourceManager _resources = new ResourceManager("Publishing.Resources.Resources", typeof(organizationForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public organizationForm()

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -12,7 +12,7 @@ namespace Publishing
         private readonly INavigationService _navigation;
         private readonly IProfileService _profileService;
         private readonly IUserSession _session;
-        private readonly ResourceManager _resources = new ResourceManager("Publishing.UI.Resources.Resources", typeof(profileForm).Assembly);
+        private readonly ResourceManager _resources = new ResourceManager("Publishing.Resources.Resources", typeof(profileForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public profileForm()


### PR DESCRIPTION
## Summary
- use correct resource namespace for shared UI strings

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855d15a08708320a1ce61cb328c546f