### PR TITLE
Add JWT header in contract tests and Swagger security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_CONN=Server=localhost;Database=Publishing;User Id=sa;Password=Your_password123;
+REDIS_CONN=redis:6379
+
+JWT__Issuer=example.com
+JWT__Audience=example.com
+JWT__SigningKey=SecretKey123
+# use the same values when generating JWT tokens

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,22 @@
+name: Contract Tests
+
+on:
+  push:
+    paths:
+      - 'src/tests/Publishing.Contracts.Tests/**'
+  pull_request:
+    paths:
+      - 'src/tests/Publishing.Contracts.Tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Run contract tests
+        run: dotnet test src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj
+

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -1,0 +1,44 @@
+name: API Gateway CI
+
+on:
+  push:
+    paths:
+      - 'src/ApiGateway/**'
+  pull_request:
+    paths:
+      - 'src/ApiGateway/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Check JWT env vars
+        run: |
+          test -n "${{ secrets.JWT__SigningKey }}" && \
+          test -n "${{ secrets.JWT__Issuer }}" && \
+          test -n "${{ secrets.JWT__Audience }}"
+      - name: Restore
+        run: dotnet restore src/ApiGateway/ApiGateway.csproj
+      - name: Build
+        run: dotnet build src/ApiGateway/ApiGateway.csproj --no-restore
+      - name: Test Core
+        run: dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build
+      - name: Test Integration
+        run: dotnet test src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj --no-build
+      - name: Build container
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/api-gateway src/ApiGateway
+      - name: Login & Push
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_USERNAME }}/api-gateway
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}

--- a/.github/workflows/orders.yml
+++ b/.github/workflows/orders.yml
@@ -1,0 +1,44 @@
+name: Orders Service CI
+
+on:
+  push:
+    paths:
+      - 'src/Publishing.Orders.Service/**'
+  pull_request:
+    paths:
+      - 'src/Publishing.Orders.Service/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Check JWT env vars
+        run: |
+          test -n "${{ secrets.JWT__SigningKey }}" && \
+          test -n "${{ secrets.JWT__Issuer }}" && \
+          test -n "${{ secrets.JWT__Audience }}"
+      - name: Restore
+        run: dotnet restore src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+      - name: Build
+        run: dotnet build src/Publishing.Orders.Service/Publishing.Orders.Service.csproj --no-restore
+      - name: Test
+        run: dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build
+      - name: Test Integration
+        run: dotnet test src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj --no-build
+      - name: Build container
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/orders-service src/Publishing.Orders.Service
+      - name: Login & Push
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_USERNAME }}/orders-service
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}

--- a/.github/workflows/organization.yml
+++ b/.github/workflows/organization.yml
@@ -1,0 +1,44 @@
+name: Organization Service CI
+
+on:
+  push:
+    paths:
+      - 'src/Publishing.Organization.Service/**'
+  pull_request:
+    paths:
+      - 'src/Publishing.Organization.Service/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Check JWT env vars
+        run: |
+          test -n "${{ secrets.JWT__SigningKey }}" && \
+          test -n "${{ secrets.JWT__Issuer }}" && \
+          test -n "${{ secrets.JWT__Audience }}"
+      - name: Restore
+        run: dotnet restore src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+      - name: Build
+        run: dotnet build src/Publishing.Organization.Service/Publishing.Organization.Service.csproj --no-restore
+      - name: Test
+        run: dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build
+      - name: Test Integration
+        run: dotnet test src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj --no-build
+      - name: Build container
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/organization-service src/Publishing.Organization.Service
+      - name: Login & Push
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_USERNAME }}/organization-service
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,44 @@
+name: Profile Service CI
+
+on:
+  push:
+    paths:
+      - 'src/Publishing.Profile.Service/**'
+  pull_request:
+    paths:
+      - 'src/Publishing.Profile.Service/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Check JWT env vars
+        run: |
+          test -n "${{ secrets.JWT__SigningKey }}" && \
+          test -n "${{ secrets.JWT__Issuer }}" && \
+          test -n "${{ secrets.JWT__Audience }}"
+      - name: Restore
+        run: dotnet restore src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+      - name: Build
+        run: dotnet build src/Publishing.Profile.Service/Publishing.Profile.Service.csproj --no-restore
+      - name: Test
+        run: dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build
+      - name: Test Integration
+        run: dotnet test src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj --no-build
+      - name: Build container
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/profile-service src/Publishing.Profile.Service
+      - name: Login & Push
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_USERNAME }}/profile-service
+        env:
+          DB_CONN: ${{ secrets.DB_CONN }}
+          REDIS_CONN: ${{ secrets.REDIS_CONN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,123 @@
+version: '3.8'
+services:
+  orders:
+    build: ./src/Publishing.Orders.Service
+    ports:
+      - "5001:80"
+    environment:
+      - DB_CONN=${DB_CONN}
+      - REDIS_CONN=${REDIS_CONN}
+      - JWT__Issuer=${JWT__Issuer}
+      - JWT__Audience=${JWT__Audience}
+      - JWT__SigningKey=${JWT__SigningKey}
+    depends_on:
+      db:
+        condition: service_started
+      cache:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - micro-net
+
+  profile:
+    build: ./src/Publishing.Profile.Service
+    ports:
+      - "5002:80"
+    environment:
+      - DB_CONN=${DB_CONN}
+      - REDIS_CONN=${REDIS_CONN}
+      - JWT__Issuer=${JWT__Issuer}
+      - JWT__Audience=${JWT__Audience}
+      - JWT__SigningKey=${JWT__SigningKey}
+    depends_on:
+      db:
+        condition: service_started
+      cache:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - micro-net
+
+  organization:
+    build: ./src/Publishing.Organization.Service
+    ports:
+      - "5003:80"
+    environment:
+      - DB_CONN=${DB_CONN}
+      - REDIS_CONN=${REDIS_CONN}
+      - JWT__Issuer=${JWT__Issuer}
+      - JWT__Audience=${JWT__Audience}
+      - JWT__SigningKey=${JWT__SigningKey}
+    depends_on:
+      db:
+        condition: service_started
+      cache:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - micro-net
+
+  gateway:
+    build: ./src/ApiGateway
+    ports:
+      - "5000:80"
+    environment:
+      - REDIS_CONN=${REDIS_CONN}
+      - JWT__Issuer=${JWT__Issuer}
+      - JWT__Audience=${JWT__Audience}
+      - JWT__SigningKey=${JWT__SigningKey}
+    depends_on:
+      orders:
+        condition: service_healthy
+      profile:
+        condition: service_healthy
+      organization:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - micro-net
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=Your_password123
+    ports:
+      - "1433:1433"
+    volumes:
+      - db-data:/var/opt/mssql
+    networks:
+      - micro-net
+
+  cache:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - micro-net
+
+networks:
+  micro-net:
+    driver: bridge
+
+volumes:
+  db-data:
+  redis-data:

--- a/src/ApiGateway/ApiGateway.csproj
+++ b/src/ApiGateway/ApiGateway.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Ocelot" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
+  </ItemGroup>
+</Project>

--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+WORKDIR /app
+COPY . ./
+ENTRYPOINT ["dotnet", "ApiGateway.dll"]

--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -1,0 +1,56 @@
+using Ocelot.DependencyInjection;
+using Ocelot.Middleware;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddJsonFile("ocelot.json", optional: false, reloadOnChange: true);
+builder.Services.AddOcelot(builder.Configuration);
+builder.Services.AddHealthChecks();
+var redisConn = builder.Configuration["REDIS_CONN"];
+if (string.IsNullOrWhiteSpace(redisConn))
+    throw new InvalidOperationException("REDIS_CONN environment variable is missing");
+builder.Services.AddStackExchangeRedisCache(o => o.Configuration = redisConn);
+var issuer = builder.Configuration["JWT:Issuer"];
+var audience = builder.Configuration["JWT:Audience"];
+var signingKey = builder.Configuration["JWT:SigningKey"];
+if (string.IsNullOrWhiteSpace(issuer) || string.IsNullOrWhiteSpace(audience) || string.IsNullOrWhiteSpace(signingKey))
+    throw new InvalidOperationException("JWT environment variables are missing");
+builder.Services.AddCors(o => o.AddDefaultPolicy(p => p.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", options =>
+    {
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = issuer,
+            ValidateAudience = true,
+            ValidAudience = audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey)),
+            ValidateLifetime = true
+        };
+    });
+builder.Services.AddAuthorization();
+builder.Services.AddOpenTelemetry().WithTracing(b =>
+    b.AddAspNetCoreInstrumentation()
+     .AddHttpClientInstrumentation()
+     .AddConsoleExporter());
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole();
+
+var app = builder.Build();
+
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+await app.UseOcelot();
+app.MapHealthChecks("/health");
+
+app.Run();

--- a/src/ApiGateway/README.md
+++ b/src/ApiGateway/README.md
@@ -1,0 +1,12 @@
+# API Gateway
+
+This gateway routes requests to the underlying services using Ocelot.
+
+## Running locally
+
+```bash
+dotnet run --project ApiGateway.csproj
+```
+
+The gateway exposes a health endpoint at `/health`. Swagger for each service is reachable via `/orders/swagger`, `/profile/swagger` and `/organization/swagger`.
+Requests are cached with Redis, traced via OpenTelemetry and secured using JWT bearer authentication.

--- a/src/ApiGateway/ocelot.json
+++ b/src/ApiGateway/ocelot.json
@@ -1,0 +1,61 @@
+{
+  "Routes": [
+    {
+      "DownstreamPathTemplate": "/api/orders/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "orders", "Port": 80 } ],
+      "UpstreamPathTemplate": "/orders/{everything}",
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE" ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/swagger/v1/swagger.json",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "orders", "Port": 80 } ],
+      "UpstreamPathTemplate": "/orders/swagger",
+      "UpstreamHttpMethod": [ "GET" ]
+    },
+    {
+      "DownstreamPathTemplate": "/api/profile/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "profile", "Port": 80 } ],
+      "UpstreamPathTemplate": "/profile/{everything}",
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE" ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/swagger/v1/swagger.json",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "profile", "Port": 80 } ],
+      "UpstreamPathTemplate": "/profile/swagger",
+      "UpstreamHttpMethod": [ "GET" ]
+    },
+    {
+      "DownstreamPathTemplate": "/api/org/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "organization", "Port": 80 } ],
+      "UpstreamPathTemplate": "/organization/{everything}",
+      "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE" ],
+      "AuthenticationOptions": {
+        "AuthenticationProviderKey": "Bearer",
+        "AllowedScopes": []
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/swagger/v1/swagger.json",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [ { "Host": "organization", "Port": 80 } ],
+      "UpstreamPathTemplate": "/organization/swagger",
+      "UpstreamHttpMethod": [ "GET" ]
+    }
+  ],
+  "GlobalConfiguration": {
+    "BaseUrl": "http://localhost:5000"
+  }
+}

--- a/src/Publishing.Orders.Service/Controllers/OrdersController.cs
+++ b/src/Publishing.Orders.Service/Controllers/OrdersController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+using Publishing.Core.Interfaces;
+using Publishing.Core.Domain;
+using MediatR;
+using Publishing.AppLayer.Commands;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.AspNetCore.Authorization;
+using System.Text.Json;
+using System.Data;
+
+namespace Publishing.Orders.Service.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly IOrderRepository _orders;
+    private readonly IDistributedCache _cache;
+
+    public OrdersController(IMediator mediator, IOrderRepository orders, IDistributedCache cache)
+    {
+        _mediator = mediator;
+        _orders = orders;
+        _cache = cache;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var cached = await _cache.GetStringAsync("orders_all");
+        if (cached != null)
+        {
+            var orders = JsonSerializer.Deserialize<List<Dictionary<string, object?>>>(cached);
+            return Ok(orders);
+        }
+
+        DataTable table = await _orders.GetAllAsync();
+        var list = table.Rows.Cast<DataRow>()
+            .Select(r => table.Columns.Cast<DataColumn>()
+                .ToDictionary(c => c.ColumnName, c => r[c]))
+            .ToList();
+        await _cache.SetStringAsync("orders_all", JsonSerializer.Serialize(list));
+        return Ok(list);
+    }
+
+    [HttpGet("person/{id}")]
+    public async Task<IActionResult> ByPerson(string id)
+    {
+        DataTable table = await _orders.GetByPersonAsync(id);
+        var list = table.Rows.Cast<DataRow>()
+            .Select(r => table.Columns.Cast<DataColumn>()
+                .ToDictionary(c => c.ColumnName, c => r[c]))
+            .ToList();
+        return Ok(list);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateOrderCommand cmd)
+    {
+        Order order = await _mediator.Send(cmd);
+        return Ok(order);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        await _orders.DeleteAsync(id);
+        await _cache.RemoveAsync("orders_all");
+        return NoContent();
+    }
+}

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+WORKDIR /app
+COPY . ./
+ENTRYPOINT ["dotnet", "Publishing.Orders.Service.dll"]

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Publishing.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Microsoft.OpenApi.Models;
+using System;
+using OpenTelemetry.Trace;
+using MediatR;
+using Publishing.AppLayer.Handlers;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = Microsoft.OpenApi.Models.SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = Microsoft.OpenApi.Models.ParameterLocation.Header
+    });
+    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+    {
+        {
+            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+            {
+                Reference = new Microsoft.OpenApi.Models.OpenApiReference
+                {
+                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+builder.Services.AddHealthChecks();
+var redisConn = builder.Configuration["REDIS_CONN"];
+if (string.IsNullOrWhiteSpace(redisConn))
+    throw new InvalidOperationException("REDIS_CONN environment variable is missing");
+builder.Services.AddStackExchangeRedisCache(o => o.Configuration = redisConn);
+var issuer = builder.Configuration["JWT:Issuer"];
+var audience = builder.Configuration["JWT:Audience"];
+var signingKey = builder.Configuration["JWT:SigningKey"];
+if (string.IsNullOrWhiteSpace(issuer) || string.IsNullOrWhiteSpace(audience) || string.IsNullOrWhiteSpace(signingKey))
+    throw new InvalidOperationException("JWT environment variables are missing");
+builder.Services.AddCors(o => o.AddDefaultPolicy(p => p.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = false;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidIssuer = issuer,
+        ValidateAudience = true,
+        ValidAudience = audience,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey)),
+        ValidateLifetime = true
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderHandler).Assembly));
+builder.Services.AddOpenTelemetry().WithTracing(b =>
+    b.AddAspNetCoreInstrumentation()
+     .AddHttpClientInstrumentation()
+     .AddEntityFrameworkCoreInstrumentation()
+     .AddConsoleExporter());
+
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole();
+
+var conn = builder.Configuration["DB_CONN"];
+if (string.IsNullOrWhiteSpace(conn))
+    throw new InvalidOperationException("DB_CONN environment variable is missing");
+builder.Services.AddDbContext<AppDbContext>(o =>
+    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+app.MapHealthChecks("/health");
+
+app.Run();

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Publishing.Core\Publishing.Core.csproj" />
+    <ProjectReference Include="..\Publishing.Infrastructure\Publishing.Infrastructure.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Publishing.Orders.Service/README.md
+++ b/src/Publishing.Orders.Service/README.md
@@ -1,0 +1,12 @@
+# Publishing Orders Service
+
+This service exposes order management HTTP APIs.
+
+## Running locally
+
+```bash
+dotnet run --project Publishing.Orders.Service.csproj
+```
+
+Swagger UI is available at `http://localhost:5001/swagger` when running via Docker Compose.
+The service applies EF Core migrations automatically at startup. Requests are cached in Redis, traced with OpenTelemetry and protected by JWT bearer authentication. Use the Swagger **Authorize** button to send a JWT when exploring endpoints.

--- a/src/Publishing.Organization.Service/Controllers/OrganizationController.cs
+++ b/src/Publishing.Organization.Service/Controllers/OrganizationController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Publishing.Core.Interfaces;
+using Publishing.Core.DTOs;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Publishing.Organization.Service.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class OrganizationController : ControllerBase
+{
+    private readonly IOrganizationService _service;
+
+    public OrganizationController(IOrganizationService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost("update")]
+    public async Task<IActionResult> Update(UpdateOrganizationDto dto)
+    {
+        await _service.UpdateAsync(dto);
+        return NoContent();
+    }
+}

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+WORKDIR /app
+COPY . ./
+ENTRYPOINT ["dotnet", "Publishing.Organization.Service.dll"]

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Publishing.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Microsoft.OpenApi.Models;
+using System;
+using OpenTelemetry.Trace;
+using MediatR;
+using Publishing.AppLayer.Handlers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+builder.Services.AddHealthChecks();
+var redisConn = builder.Configuration["REDIS_CONN"];
+if (string.IsNullOrWhiteSpace(redisConn))
+    throw new InvalidOperationException("REDIS_CONN environment variable is missing");
+builder.Services.AddStackExchangeRedisCache(o => o.Configuration = redisConn);
+var issuer = builder.Configuration["JWT:Issuer"];
+var audience = builder.Configuration["JWT:Audience"];
+var signingKey = builder.Configuration["JWT:SigningKey"];
+if (string.IsNullOrWhiteSpace(issuer) || string.IsNullOrWhiteSpace(audience) || string.IsNullOrWhiteSpace(signingKey))
+    throw new InvalidOperationException("JWT environment variables are missing");
+builder.Services.AddCors(o => o.AddDefaultPolicy(p => p.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = false;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidIssuer = issuer,
+        ValidateAudience = true,
+        ValidAudience = audience,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey)),
+        ValidateLifetime = true
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderHandler).Assembly));
+builder.Services.AddOpenTelemetry().WithTracing(b =>
+    b.AddAspNetCoreInstrumentation()
+     .AddHttpClientInstrumentation()
+     .AddEntityFrameworkCoreInstrumentation()
+     .AddConsoleExporter());
+
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole();
+
+var conn = builder.Configuration["DB_CONN"];
+if (string.IsNullOrWhiteSpace(conn))
+    throw new InvalidOperationException("DB_CONN environment variable is missing");
+builder.Services.AddDbContext<AppDbContext>(o =>
+    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+app.MapHealthChecks("/health");
+
+app.Run();

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Publishing.Core\Publishing.Core.csproj" />
+    <ProjectReference Include="..\Publishing.Infrastructure\Publishing.Infrastructure.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Publishing.Organization.Service/README.md
+++ b/src/Publishing.Organization.Service/README.md
@@ -1,0 +1,12 @@
+# Publishing Organization Service
+
+This service manages organization data.
+
+## Running locally
+
+```bash
+dotnet run --project Publishing.Organization.Service.csproj
+```
+
+Swagger UI is available at `http://localhost:5003/swagger` when running via Docker Compose.
+The service applies EF Core migrations automatically at startup. Redis caching, OpenTelemetry tracing and JWT bearer authentication are enabled by default. Use Swagger's **Authorize** button to supply a JWT when trying endpoints.

--- a/src/Publishing.Profile.Service/Controllers/ProfileController.cs
+++ b/src/Publishing.Profile.Service/Controllers/ProfileController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using Publishing.Core.Interfaces;
+using Publishing.Core.DTOs;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Publishing.Profile.Service.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class ProfileController : ControllerBase
+{
+    private readonly IProfileService _service;
+    private readonly IDistributedCache _cache;
+
+    public ProfileController(IProfileService service, IDistributedCache cache)
+    {
+        _service = service;
+        _cache = cache;
+    }
+
+    [HttpPost("update")]
+    public async Task<IActionResult> Update(UpdateProfileDto dto)
+    {
+        await _service.UpdateAsync(dto);
+        await _cache.RemoveAsync("orders_all");
+        return NoContent();
+    }
+}

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+WORKDIR /app
+COPY . ./
+ENTRYPOINT ["dotnet", "Publishing.Profile.Service.dll"]

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Publishing.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Microsoft.OpenApi.Models;
+using System;
+using OpenTelemetry.Trace;
+using MediatR;
+using Publishing.AppLayer.Handlers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+builder.Services.AddHealthChecks();
+var redisConn = builder.Configuration["REDIS_CONN"];
+if (string.IsNullOrWhiteSpace(redisConn))
+    throw new InvalidOperationException("REDIS_CONN environment variable is missing");
+builder.Services.AddStackExchangeRedisCache(o => o.Configuration = redisConn);
+var issuer = builder.Configuration["JWT:Issuer"];
+var audience = builder.Configuration["JWT:Audience"];
+var signingKey = builder.Configuration["JWT:SigningKey"];
+if (string.IsNullOrWhiteSpace(issuer) || string.IsNullOrWhiteSpace(audience) || string.IsNullOrWhiteSpace(signingKey))
+    throw new InvalidOperationException("JWT environment variables are missing");
+builder.Services.AddCors(o => o.AddDefaultPolicy(p => p.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = false;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidIssuer = issuer,
+        ValidateAudience = true,
+        ValidAudience = audience,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey)),
+        ValidateLifetime = true
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(CreateOrderHandler).Assembly));
+builder.Services.AddOpenTelemetry().WithTracing(b =>
+    b.AddAspNetCoreInstrumentation()
+     .AddHttpClientInstrumentation()
+     .AddEntityFrameworkCoreInstrumentation()
+     .AddConsoleExporter());
+
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole();
+
+var conn = builder.Configuration["DB_CONN"];
+if (string.IsNullOrWhiteSpace(conn))
+    throw new InvalidOperationException("DB_CONN environment variable is missing");
+builder.Services.AddDbContext<AppDbContext>(o =>
+    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+app.MapHealthChecks("/health");
+
+app.Run();

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Publishing.Core\Publishing.Core.csproj" />
+    <ProjectReference Include="..\Publishing.Infrastructure\Publishing.Infrastructure.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Publishing.Profile.Service/README.md
+++ b/src/Publishing.Profile.Service/README.md
@@ -1,0 +1,12 @@
+# Publishing Profile Service
+
+This service handles user profile operations.
+
+## Running locally
+
+```bash
+dotnet run --project Publishing.Profile.Service.csproj
+```
+
+Swagger UI is available at `http://localhost:5002/swagger` when running via Docker Compose.
+The service applies EF Core migrations automatically at startup and uses Redis caching, OpenTelemetry tracing and JWT bearer authentication. Use the Swagger **Authorize** button to test secured endpoints.

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PactNet;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Publishing.Contracts.Tests;
+
+[TestClass]
+public class OrderContracts
+{
+    private static string CreateJwt()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: "example.com",
+            audience: "example.com",
+            claims: new[] { new Claim("sub", "contract-test") },
+            expires: DateTime.UtcNow.AddMinutes(5),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [TestMethod]
+    public async Task GetOrders_VerifyContract()
+    {
+        var pact = Pact.V3("OrdersService", "Gateway", new PactConfig());
+        pact
+            .UponReceiving("A GET request to retrieve orders")
+            .WithRequest(HttpMethod.Get, "/orders/api/orders")
+            .WillRespond()
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/orders/api/orders");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
+    }
+}

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PactNet;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Publishing.Contracts.Tests;
+
+[TestClass]
+public class OrganizationContracts
+{
+    private static string CreateJwt()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: "example.com",
+            audience: "example.com",
+            claims: new[] { new Claim("sub", "contract-test") },
+            expires: DateTime.UtcNow.AddMinutes(5),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [TestMethod]
+    public async Task GetOrganizations_VerifyContract()
+    {
+        var pact = Pact.V3("OrganizationService", "Gateway", new PactConfig());
+        pact
+            .UponReceiving("A GET request to retrieve organizations")
+            .WithRequest(HttpMethod.Get, "/organization/api/organization")
+            .WillRespond()
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/organization/api/organization");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
+    }
+}

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PactNet;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Publishing.Contracts.Tests;
+
+[TestClass]
+public class ProfileContracts
+{
+    private static string CreateJwt()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: "example.com",
+            audience: "example.com",
+            claims: new[] { new Claim("sub", "contract-test") },
+            expires: DateTime.UtcNow.AddMinutes(5),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [TestMethod]
+    public async Task GetProfiles_VerifyContract()
+    {
+        var pact = Pact.V3("ProfileService", "Gateway", new PactConfig());
+        pact
+            .UponReceiving("A GET request to retrieve profiles")
+            .WithRequest(HttpMethod.Get, "/profile/api/profile")
+            .WillRespond()
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/profile/api/profile");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
+    }
+}

--- a/src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj
+++ b/src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="PactNet" Version="4.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- update Pact contract tests to send JWT tokens
- secure Swagger with a Bearer scheme for each service
- mention using the Authorize button in documentation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dead2a0883208d09de6bbfc73126