### PR TITLE
Fix PactNet contract tests

### DIFF
--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using PactNet.Matchers;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -31,19 +31,17 @@ public class OrderContracts
     [TestMethod]
     public async Task GetOrders_VerifyContract()
     {
-        var pact = Pact.V3("OrdersService", "Gateway", new PactConfig());
-        pact
+        await Pact.V3("OrdersService", "Gateway", new PactConfig())
             .UponReceiving("A GET request to retrieve orders")
             .WithRequest(HttpMethod.Get, "/orders/api/orders")
             .WillRespond()
-            .WithStatus(200);
-
-        await pact.VerifyAsync(async ctx =>
-        {
-            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-            var response = await client.GetAsync("/orders/api/orders");
-            Assert.IsTrue(response.IsSuccessStatusCode);
-        });
+            .WithStatus(200)
+            .VerifyAsync(async ctx =>
+            {
+                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+                var response = await client.GetAsync("/orders/api/orders");
+                Assert.IsTrue(response.IsSuccessStatusCode);
+            });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -31,17 +31,19 @@ public class OrderContracts
     [TestMethod]
     public async Task GetOrders_VerifyContract()
     {
-        await Pact.V3("OrdersService", "Gateway", new PactConfig())
+        var pact = Pact.V3("OrdersService", "Gateway", new PactConfig());
+        pact
             .UponReceiving("A GET request to retrieve orders")
             .WithRequest(HttpMethod.Get, "/orders/api/orders")
             .WillRespond()
-            .WithStatus(200)
-            .VerifyAsync(async ctx =>
-            {
-                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-                var response = await client.GetAsync("/orders/api/orders");
-                Assert.IsTrue(response.IsSuccessStatusCode);
-            });
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/orders/api/orders");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using PactNet.Matchers;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -31,17 +31,19 @@ public class OrganizationContracts
     [TestMethod]
     public async Task GetOrganizations_VerifyContract()
     {
-        await Pact.V3("OrganizationService", "Gateway", new PactConfig())
+        var pact = Pact.V3("OrganizationService", "Gateway", new PactConfig());
+        pact
             .UponReceiving("A GET request to retrieve organizations")
             .WithRequest(HttpMethod.Get, "/organization/api/organization")
             .WillRespond()
-            .WithStatus(200)
-            .VerifyAsync(async ctx =>
-            {
-                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-                var response = await client.GetAsync("/organization/api/organization");
-                Assert.IsTrue(response.IsSuccessStatusCode);
-            });
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/organization/api/organization");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -31,19 +31,17 @@ public class OrganizationContracts
     [TestMethod]
     public async Task GetOrganizations_VerifyContract()
     {
-        var pact = Pact.V3("OrganizationService", "Gateway", new PactConfig());
-        pact
+        await Pact.V3("OrganizationService", "Gateway", new PactConfig())
             .UponReceiving("A GET request to retrieve organizations")
             .WithRequest(HttpMethod.Get, "/organization/api/organization")
             .WillRespond()
-            .WithStatus(200);
-
-        await pact.VerifyAsync(async ctx =>
-        {
-            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-            var response = await client.GetAsync("/organization/api/organization");
-            Assert.IsTrue(response.IsSuccessStatusCode);
-        });
+            .WithStatus(200)
+            .VerifyAsync(async ctx =>
+            {
+                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+                var response = await client.GetAsync("/organization/api/organization");
+                Assert.IsTrue(response.IsSuccessStatusCode);
+            });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PactNet;
+using PactNet.Matchers;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -31,17 +31,19 @@ public class ProfileContracts
     [TestMethod]
     public async Task GetProfiles_VerifyContract()
     {
-        await Pact.V3("ProfileService", "Gateway", new PactConfig())
+        var pact = Pact.V3("ProfileService", "Gateway", new PactConfig());
+        pact
             .UponReceiving("A GET request to retrieve profiles")
             .WithRequest(HttpMethod.Get, "/profile/api/profile")
             .WillRespond()
-            .WithStatus(200)
-            .VerifyAsync(async ctx =>
-            {
-                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-                var response = await client.GetAsync("/profile/api/profile");
-                Assert.IsTrue(response.IsSuccessStatusCode);
-            });
+            .WithStatus(200);
+
+        await pact.VerifyAsync(async ctx =>
+        {
+            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+            var response = await client.GetAsync("/profile/api/profile");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -31,19 +31,17 @@ public class ProfileContracts
     [TestMethod]
     public async Task GetProfiles_VerifyContract()
     {
-        var pact = Pact.V3("ProfileService", "Gateway", new PactConfig());
-        pact
+        await Pact.V3("ProfileService", "Gateway", new PactConfig())
             .UponReceiving("A GET request to retrieve profiles")
             .WithRequest(HttpMethod.Get, "/profile/api/profile")
             .WillRespond()
-            .WithStatus(200);
-
-        await pact.VerifyAsync(async ctx =>
-        {
-            using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
-            var response = await client.GetAsync("/profile/api/profile");
-            Assert.IsTrue(response.IsSuccessStatusCode);
-        });
+            .WithStatus(200)
+            .VerifyAsync(async ctx =>
+            {
+                using var client = new HttpClient { BaseAddress = ctx.MockServerUri };
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt());
+                var response = await client.GetAsync("/profile/api/profile");
+                Assert.IsTrue(response.IsSuccessStatusCode);
+            });
     }
 }

--- a/src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj
+++ b/src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PactNet" Version="4.2.5" />
+    <PackageReference Include="PactNet" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />


### PR DESCRIPTION
## Summary
- add missing `System` namespace to contract tests
- update PactNet package reference

## Testing
- `dotnet test src/tests/Publishing.Contracts.Tests/Publishing.Contracts.Tests.csproj -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856af8029f083208c80018a923c3814