### PR TITLE
Fix docker builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-DB_CONN=Server=localhost;Database=Publishing;User Id=sa;Password=Your_password123;
+DB_CONN=Server=db;Database=Publishing;User Id=sa;Password=Your_password123;TrustServerCertificate=True;
 REDIS_CONN=redis:6379
 
 JWT__Issuer=example.com
 JWT__Audience=example.com
-JWT__SigningKey=SecretKey123
+JWT__SigningKey=YOUR_SECRET_KEY_HERE
 # use the same values when generating JWT tokens

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Environment variable files
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3.8'
 services:
   orders:
-    build: ./src/Publishing.Orders.Service
+    build:
+      context: .
+      dockerfile: src/Publishing.Orders.Service/Dockerfile
     ports:
       - "5001:80"
     environment:
@@ -24,7 +25,9 @@ services:
       - micro-net
 
   profile:
-    build: ./src/Publishing.Profile.Service
+    build:
+      context: .
+      dockerfile: src/Publishing.Profile.Service/Dockerfile
     ports:
       - "5002:80"
     environment:
@@ -47,7 +50,9 @@ services:
       - micro-net
 
   organization:
-    build: ./src/Publishing.Organization.Service
+    build:
+      context: .
+      dockerfile: src/Publishing.Organization.Service/Dockerfile
     ports:
       - "5003:80"
     environment:
@@ -70,7 +75,9 @@ services:
       - micro-net
 
   gateway:
-    build: ./src/ApiGateway
+    build:
+      context: .
+      dockerfile: src/ApiGateway/Dockerfile
     ports:
       - "5000:80"
     environment:

--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -1,4 +1,22 @@
+# ------------------------------------------------------------
+# 1) Build stage using the .NET SDK
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+
+# 1.1) Copy the project file and restore dependencies
+COPY ["src/ApiGateway/ApiGateway.csproj", "ApiGateway/"]
+RUN dotnet restore "ApiGateway/ApiGateway.csproj"
+
+# 1.2) Copy the remaining source and publish
+COPY . .
+WORKDIR "/src/ApiGateway"
+RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
+
+# ------------------------------------------------------------
+# 2) Runtime stage with ASP.NET Core Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 WORKDIR /app
-COPY . ./
+
+COPY --from=build /app/publish .
+
 ENTRYPOINT ["dotnet", "ApiGateway.dll"]

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -1,4 +1,22 @@
+# ------------------------------------------------------------
+# 1) Build stage using the .NET SDK
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+
+# 1.1) Copy the project file and restore dependencies
+COPY ["src/Publishing.Orders.Service/Publishing.Orders.Service.csproj", "Publishing.Orders.Service/"]
+RUN dotnet restore "Publishing.Orders.Service/Publishing.Orders.Service.csproj"
+
+# 1.2) Copy the remaining source and publish
+COPY . .
+WORKDIR "/src/Publishing.Orders.Service"
+RUN dotnet publish "Publishing.Orders.Service.csproj" -c Release -o /app/publish
+
+# ------------------------------------------------------------
+# 2) Runtime stage with ASP.NET Core Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 WORKDIR /app
-COPY . ./
+
+COPY --from=build /app/publish .
+
 ENTRYPOINT ["dotnet", "Publishing.Orders.Service.dll"]

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -1,4 +1,22 @@
+# ------------------------------------------------------------
+# 1) Build stage using the .NET SDK
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+
+# 1.1) Copy the project file and restore dependencies
+COPY ["src/Publishing.Organization.Service/Publishing.Organization.Service.csproj", "Publishing.Organization.Service/"]
+RUN dotnet restore "Publishing.Organization.Service/Publishing.Organization.Service.csproj"
+
+# 1.2) Copy the rest of the source and publish
+COPY . .
+WORKDIR "/src/Publishing.Organization.Service"
+RUN dotnet publish "Publishing.Organization.Service.csproj" -c Release -o /app/publish
+
+# ------------------------------------------------------------
+# 2) Runtime stage with ASP.NET Core Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 WORKDIR /app
-COPY . ./
+
+COPY --from=build /app/publish .
+
 ENTRYPOINT ["dotnet", "Publishing.Organization.Service.dll"]

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -1,4 +1,22 @@
+# ------------------------------------------------------------
+# 1) Build stage using the .NET SDK
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+
+# 1.1) Copy the project file and restore dependencies
+COPY ["src/Publishing.Profile.Service/Publishing.Profile.Service.csproj", "Publishing.Profile.Service/"]
+RUN dotnet restore "Publishing.Profile.Service/Publishing.Profile.Service.csproj"
+
+# 1.2) Copy the rest of the source and publish
+COPY . .
+WORKDIR "/src/Publishing.Profile.Service"
+RUN dotnet publish "Publishing.Profile.Service.csproj" -c Release -o /app/publish
+
+# ------------------------------------------------------------
+# 2) Runtime stage with ASP.NET Core Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 WORKDIR /app
-COPY . ./
+
+COPY --from=build /app/publish .
+
 ENTRYPOINT ["dotnet", "Publishing.Profile.Service.dll"]


### PR DESCRIPTION
## Summary
- publish services with multi-stage Dockerfiles
- update docker-compose build contexts
- remove outdated version line and add environment file
- add multi-stage build for API gateway
- add certificate trust to DB connection
- remove tracked `.env` and replace with `.env.example`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*
- `docker compose down` *(fails: `docker: command not found`)*
- `docker compose up --build -d` *(fails: `docker: command not found`)*
- `docker compose ps` *(fails: `docker: command not found`)*
- `docker compose logs -f` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc5f2b6883209bf573b6c17aa448