### PR TITLE
Fix docker restore paths

### DIFF
--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -3,13 +3,14 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy the project file and restore dependencies
-COPY ["src/ApiGateway/ApiGateway.csproj", "ApiGateway/"]
-RUN dotnet restore "ApiGateway/ApiGateway.csproj"
+# 1.1) Copy solution and all csproj for restore
+COPY ["Publishing.sln", "."]
+COPY ["src/ApiGateway/ApiGateway.csproj", "src/ApiGateway/"]
+RUN dotnet restore "Publishing.sln"
 
 # 1.2) Copy the remaining source and publish
 COPY . .
-WORKDIR "/src/ApiGateway"
+WORKDIR "/src/src/ApiGateway"
 RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -3,13 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy the project file and restore dependencies
-COPY ["src/Publishing.Orders.Service/Publishing.Orders.Service.csproj", "Publishing.Orders.Service/"]
-RUN dotnet restore "Publishing.Orders.Service/Publishing.Orders.Service.csproj"
+# 1.1) Copy solution and all csproj for restore
+COPY ["Publishing.sln", "."]
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
+COPY ["src/Publishing.Orders.Service/Publishing.Orders.Service.csproj", "src/Publishing.Orders.Service/"]
+RUN dotnet restore "Publishing.sln"
 
 # 1.2) Copy the remaining source and publish
 COPY . .
-WORKDIR "/src/Publishing.Orders.Service"
+WORKDIR "/src/src/Publishing.Orders.Service"
 RUN dotnet publish "Publishing.Orders.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -3,13 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy the project file and restore dependencies
-COPY ["src/Publishing.Organization.Service/Publishing.Organization.Service.csproj", "Publishing.Organization.Service/"]
-RUN dotnet restore "Publishing.Organization.Service/Publishing.Organization.Service.csproj"
+# 1.1) Copy solution and all csproj for restore
+COPY ["Publishing.sln", "."]
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
+COPY ["src/Publishing.Organization.Service/Publishing.Organization.Service.csproj", "src/Publishing.Organization.Service/"]
+RUN dotnet restore "Publishing.sln"
 
 # 1.2) Copy the rest of the source and publish
 COPY . .
-WORKDIR "/src/Publishing.Organization.Service"
+WORKDIR "/src/src/Publishing.Organization.Service"
 RUN dotnet publish "Publishing.Organization.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -3,13 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy the project file and restore dependencies
-COPY ["src/Publishing.Profile.Service/Publishing.Profile.Service.csproj", "Publishing.Profile.Service/"]
-RUN dotnet restore "Publishing.Profile.Service/Publishing.Profile.Service.csproj"
+# 1.1) Copy solution and all csproj for restore
+COPY ["Publishing.sln", "."]
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
+COPY ["src/Publishing.Profile.Service/Publishing.Profile.Service.csproj", "src/Publishing.Profile.Service/"]
+RUN dotnet restore "Publishing.sln"
 
 # 1.2) Copy the rest of the source and publish
 COPY . .
-WORKDIR "/src/Publishing.Profile.Service"
+WORKDIR "/src/src/Publishing.Profile.Service"
 RUN dotnet publish "Publishing.Profile.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- copy solution and dependency projects for restore in all Dockerfiles
- correct MediatR package version across services

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856d8fe2f9c83208f26bc9414b62dad