### PR TITLE
Fix Dockerfile restore paths

### DIFF
--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -3,14 +3,14 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy solution and all csproj for restore
-COPY ["Publishing.sln", "."]
-COPY ["src/ApiGateway/ApiGateway.csproj", "src/ApiGateway/"]
-RUN dotnet restore "Publishing.sln"
+# 1.1) Copy only the project needed for ApiGateway
+COPY ["src/ApiGateway/ApiGateway.csproj", "ApiGateway/"]
+# 1.2) Restore only ApiGateway
+RUN dotnet restore "ApiGateway/ApiGateway.csproj"
 
-# 1.2) Copy the remaining source and publish
-COPY . .
-WORKDIR "/src/src/ApiGateway"
+# 1.3) Copy the remaining source and publish
+COPY src/ApiGateway/. "ApiGateway/"
+WORKDIR "/src/ApiGateway"
 RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -3,17 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy solution and all csproj for restore
-COPY ["Publishing.sln", "."]
-COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
-COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
-COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
-COPY ["src/Publishing.Orders.Service/Publishing.Orders.Service.csproj", "src/Publishing.Orders.Service/"]
-RUN dotnet restore "Publishing.sln"
+# 1.1) Copy only the projects needed for Orders.Service
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "Publishing.Application/"]
+COPY ["src/Publishing.Orders.Service/Publishing.Orders.Service.csproj", "Publishing.Orders.Service/"]
+# 1.2) Restore only Orders.Service (it will pull its ProjectReferences)
+RUN dotnet restore "Publishing.Orders.Service/Publishing.Orders.Service.csproj"
 
-# 1.2) Copy the remaining source and publish
-COPY . .
-WORKDIR "/src/src/Publishing.Orders.Service"
+# 1.3) Copy rest of source and publish
+COPY src/Publishing.Orders.Service/. "Publishing.Orders.Service/"
+WORKDIR "/src/Publishing.Orders.Service"
 RUN dotnet publish "Publishing.Orders.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -3,17 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy solution and all csproj for restore
-COPY ["Publishing.sln", "."]
-COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
-COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
-COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
-COPY ["src/Publishing.Organization.Service/Publishing.Organization.Service.csproj", "src/Publishing.Organization.Service/"]
-RUN dotnet restore "Publishing.sln"
+# 1.1) Copy only the projects needed for Organization.Service
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "Publishing.Application/"]
+COPY ["src/Publishing.Organization.Service/Publishing.Organization.Service.csproj", "Publishing.Organization.Service/"]
+# 1.2) Restore only Organization.Service (it will pull its ProjectReferences)
+RUN dotnet restore "Publishing.Organization.Service/Publishing.Organization.Service.csproj"
 
-# 1.2) Copy the rest of the source and publish
-COPY . .
-WORKDIR "/src/src/Publishing.Organization.Service"
+# 1.3) Copy rest of source and publish
+COPY src/Publishing.Organization.Service/. "Publishing.Organization.Service/"
+WORKDIR "/src/Publishing.Organization.Service"
 RUN dotnet publish "Publishing.Organization.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -3,17 +3,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-# 1.1) Copy solution and all csproj for restore
-COPY ["Publishing.sln", "."]
-COPY ["src/Publishing.Core/Publishing.Core.csproj", "src/Publishing.Core/"]
-COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "src/Publishing.Infrastructure/"]
-COPY ["src/Publishing.Application/Publishing.Application.csproj", "src/Publishing.Application/"]
-COPY ["src/Publishing.Profile.Service/Publishing.Profile.Service.csproj", "src/Publishing.Profile.Service/"]
-RUN dotnet restore "Publishing.sln"
+# 1.1) Copy only the projects needed for Profile.Service
+COPY ["src/Publishing.Core/Publishing.Core.csproj", "Publishing.Core/"]
+COPY ["src/Publishing.Infrastructure/Publishing.Infrastructure.csproj", "Publishing.Infrastructure/"]
+COPY ["src/Publishing.Application/Publishing.Application.csproj", "Publishing.Application/"]
+COPY ["src/Publishing.Profile.Service/Publishing.Profile.Service.csproj", "Publishing.Profile.Service/"]
+# 1.2) Restore only Profile.Service (it will pull its ProjectReferences)
+RUN dotnet restore "Publishing.Profile.Service/Publishing.Profile.Service.csproj"
 
-# 1.2) Copy the rest of the source and publish
-COPY . .
-WORKDIR "/src/src/Publishing.Profile.Service"
+# 1.3) Copy rest of source and publish
+COPY src/Publishing.Profile.Service/. "Publishing.Profile.Service/"
+WORKDIR "/src/Publishing.Profile.Service"
 RUN dotnet publish "Publishing.Profile.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix restore steps in service Dockerfiles so only relevant csproj files are restored
- adjust source copying paths accordingly

## Testing
- `dotnet --version` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dbddbc048320945b4e34754b4fca