### PR TITLE
Fix MediatR references in services

### DIFF
--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update MediatR package references in service projects

## Testing
- `docker compose down` *(fails: command not found)*
- `docker compose up --build -d` *(fails: command not found)*
- `docker compose ps` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856de7e1f08832097100562a8c231f0