### PR TITLE
Update OpenTelemetry.Extensions.DependencyInjection

### DIFF
--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.12.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.12.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9.10" />
-    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.DependencyInjection" Version="1.12.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- bump `OpenTelemetry.Extensions.DependencyInjection` package in service csproj files to v1.12.0

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e7cbe0b08320b6b237b8a444df11