### PR TITLE
Pass env vars to DB container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-DB_CONN=Server=db;Database=Publishing;User Id=sa;Password=Your_password123;TrustServerCertificate=True;
+SA_PASSWORD=Your_password123
+ACCEPT_EULA=Y
+
+DB_CONN=Server=db;Database=Publishing;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=True
 REDIS_CONN=redis:6379
 
 JWT__Issuer=example.com

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker-compose up --build
 ```
 
 The API gateway project under `src/ApiGateway` routes requests to the services. Swagger is enabled for each service at `/swagger` and health checks are exposed at `/health`.
-Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `DB_CONN`, `REDIS_CONN`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
+Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `SA_PASSWORD`, `ACCEPT_EULA`, `DB_CONN`, `REDIS_CONN`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
 The issuer, audience and signing key must match the values used to sign JWT tokens consumed by the services.
 All API routes require an `Authorization: Bearer <token>` header containing a JWT signed with the configured key.
 When browsing Swagger, use the **Authorize** button to provide a token for authenticated requests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,8 +103,8 @@ services:
   db:
     image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Your_password123
+      - ACCEPT_EULA=${ACCEPT_EULA}
+      - SA_PASSWORD=${SA_PASSWORD}
     ports:
       - "1433:1433"
     volumes:


### PR DESCRIPTION
## Summary
- allow configuring SA_PASSWORD and ACCEPT_EULA via environment variables
- reference them in docker-compose
- document required variables

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3fe061c83208d890308d25147a9