### PR TITLE
Add db healthcheck and wait for service to be healthy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       - JWT__SigningKey=${JWT__SigningKey}
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       cache:
         condition: service_started
+    restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       interval: 10s
@@ -38,9 +39,10 @@ services:
       - JWT__SigningKey=${JWT__SigningKey}
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       cache:
         condition: service_started
+    restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       interval: 10s
@@ -63,9 +65,10 @@ services:
       - JWT__SigningKey=${JWT__SigningKey}
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       cache:
         condition: service_started
+    restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       interval: 10s
@@ -105,6 +108,11 @@ services:
     environment:
       - ACCEPT_EULA=${ACCEPT_EULA}
       - SA_PASSWORD=${SA_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -Q \"SELECT 1\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
       - "1433:1433"
     volumes:


### PR DESCRIPTION
## Summary
- add a health check for the SQL Server container
- wait for db health before starting services
- restart dependent services on failure

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f8c301ac83208a951fb21e7f2e69