### PR TITLE
Fix SQL healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - ACCEPT_EULA=${ACCEPT_EULA}
       - SA_PASSWORD=${SA_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -Q \"SELECT 1\""]
+      test: ["CMD-SHELL", "pidof sqlservr"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- check that `sqlservr` process is running instead of using missing `sqlcmd` binary

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fad2b33c8320a20f55687b057600