### PR TITLE
Add service dependency for DB initialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_started
+      organization:
+        condition: service_healthy
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
@@ -42,6 +44,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_started
+      organization:
+        condition: service_healthy
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]


### PR DESCRIPTION
## Summary
- ensure orders and profile services start after organization

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fc48309c8320834672ca72f92fc9