### PR TITLE
Remove DB creation from non-migrating services

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -87,11 +87,6 @@ builder.Services.AddDbContext<AppDbContext>(o =>
 
 var app = builder.Build();
 
-using (var scope = app.Services.CreateScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    db.Database.Migrate();
-}
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -87,11 +87,6 @@ builder.Services.AddDbContext<AppDbContext>(o =>
 
 var app = builder.Build();
 
-using (var scope = app.Services.CreateScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    db.Database.Migrate();
-}
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -37,12 +37,7 @@ namespace Publishing
             ConfigureServices(services);
             Services = services.BuildServiceProvider();
 
-            // Apply any pending EF Core migrations before showing the UI
-            using (var scope = Services.CreateScope())
-            {
-                var init = scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>();
-                init.InitializeAsync().GetAwaiter().GetResult();
-            }
+
 
             var form = Services.GetRequiredService<loginForm>();
             System.Windows.Forms.Application.Run(form);
@@ -101,7 +96,6 @@ namespace Publishing
                     TimeSpan.FromMinutes(10)));
             services.AddSingleton<ICommandDispatcher, CommandDispatcher>();
             services.AddTransient<IDbContext, DapperDbContext>();
-            services.AddTransient<IDatabaseInitializer, DatabaseInitializer>();
             services.AddScoped<IDbHelper, DbHelper>();
             services.AddScoped<ILoginRepository, LoginRepository>();
             services.AddScoped<IAuthService, AuthService>();


### PR DESCRIPTION
## Summary
- avoid auto database creation on Orders, Profile and UI services
- keep migration in Organization service

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856feb5c1a4832099d03a750e003bdb