### PR TITLE
Update healthcheck settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,10 @@ services:
         condition: service_started
     restart: on-failure
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
       interval: 10s
       timeout: 5s
+      start_period: 15s
       retries: 5
     networks:
       - micro-net


### PR DESCRIPTION
## Summary
- improve docker healthcheck for Organization service

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857028487948320b7050b4ab5122e0c