### PR TITLE
Add explicit health check route

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -39,7 +39,6 @@ builder.Services.AddSwaggerGen(c =>
         }
     });
 });
-builder.Services.AddHealthChecks();
 var redisConn = builder.Configuration["REDIS_CONN"];
 if (string.IsNullOrWhiteSpace(redisConn))
     throw new InvalidOperationException("REDIS_CONN environment variable is missing");
@@ -78,6 +77,9 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -39,7 +39,6 @@ builder.Services.AddSwaggerGen(c =>
         }
     });
 });
-builder.Services.AddHealthChecks();
 var redisConn = builder.Configuration["REDIS_CONN"];
 if (string.IsNullOrWhiteSpace(redisConn))
     throw new InvalidOperationException("REDIS_CONN environment variable is missing");
@@ -78,6 +77,9 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
@@ -103,6 +105,8 @@ app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+
+// Map health check endpoint so Docker can check container status
 app.MapHealthChecks("/health");
 
 app.Run();

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -39,7 +39,6 @@ builder.Services.AddSwaggerGen(c =>
         }
     });
 });
-builder.Services.AddHealthChecks();
 var redisConn = builder.Configuration["REDIS_CONN"];
 if (string.IsNullOrWhiteSpace(redisConn))
     throw new InvalidOperationException("REDIS_CONN environment variable is missing");
@@ -78,6 +77,9 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))


### PR DESCRIPTION
## Summary
- clarify health check mapping for Organization service
- make sure all services register DB health checks

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571df076888320b7957005d2376740