### PR TITLE
Add EF Core health checks

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.OpenApi.Models;
@@ -77,15 +79,16 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
-builder.Services
-    .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var app = builder.Build();
 

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -3,6 +3,8 @@ using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Text;
 using Microsoft.OpenApi.Models;
 using System;
@@ -77,15 +79,16 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
-builder.Services
-    .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var app = builder.Build();
 

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -77,15 +79,16 @@ builder.Services.AddOpenTelemetry().WithTracing(b =>
 
 builder.Logging.ClearProviders();
 builder.Logging.AddJsonConsole();
-builder.Services
-    .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>("Database");
 
 var conn = builder.Configuration["DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+
+builder.Services
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>("Database");
 
 var app = builder.Build();
 

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add EF Core health check package to each service project
- include required namespaces in service startup files
- register DB health checks after configuring DbContext

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685729b6f1988320a1d8fc437846ea91