### PR TITLE
Add start_period for organization service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
       interval: 10s
       timeout: 5s
-      start_period: 15s
+      start_period: 30s
       retries: 5
     networks:
       - micro-net


### PR DESCRIPTION
## Summary
- extend `start_period` to `30s` for the organization service healthcheck

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685734b1a5388320ac24712ae19f1270