### PR TITLE
Enable async migrations and Swagger helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ docker-compose up --build
 The API gateway project under `src/ApiGateway` routes requests to the services. Swagger is enabled for each service at `/swagger` and health checks are exposed at `/health`.
 Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `SA_PASSWORD`, `ACCEPT_EULA`, `DB_CONN`, `REDIS_CONN`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
 The issuer, audience and signing key must match the values used to sign JWT tokens consumed by the services.
+Set `ASPNETCORE_ENVIRONMENT=Development` in the compose file (or `.env`) to enable Swagger inside the containers. Change or remove this variable to run the services in production.
+Database migrations now apply **asynchronously** during startup and each service reports readiness via `/health`.
 All API routes require an `Authorization: Bearer <token>` header containing a JWT signed with the configured key.
 When browsing Swagger, use the **Authorize** button to provide a token for authenticated requests.
 Persistent volumes `db-data` and `redis-data` preserve SQL Server and Redis data between restarts. The services automatically apply EF Core migrations using the `DB_CONN` connection string. All containers join the `micro-net` Docker network so the gateway can resolve service names. Swagger can also be reached through the gateway under `/orders/swagger`, `/profile/swagger` and `/organization/swagger`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - JWT__Issuer=${JWT__Issuer}
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
+      - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
       db:
         condition: service_healthy
@@ -39,6 +40,7 @@ services:
       - JWT__Issuer=${JWT__Issuer}
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
+      - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
       db:
         condition: service_healthy
@@ -67,6 +69,7 @@ services:
       - JWT__Issuer=${JWT__Issuer}
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
+      - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
       db:
         condition: service_healthy
@@ -93,6 +96,7 @@ services:
       - JWT__Issuer=${JWT__Issuer}
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
+      - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
       orders:
         condition: service_healthy

--- a/src/Publishing.Infrastructure/AppDbContext.cs
+++ b/src/Publishing.Infrastructure/AppDbContext.cs
@@ -72,7 +72,9 @@ namespace Publishing.Infrastructure
                 entity.Property(e => e.DateFinish).HasColumnName("dateFinish");
                 entity.Property(e => e.Status).HasColumnName("statusOrder");
                 entity.Property(e => e.Tirage).HasColumnName("tirage");
-                entity.Property(e => e.Price).HasColumnName("price");
+                entity.Property(e => e.Price)
+                      .HasColumnName("price")
+                      .HasPrecision(18, 2);
                 entity.HasOne(e => e.Product)
                       .WithMany(p => p.Orders)
                       .HasForeignKey(e => e.ProductId)

--- a/src/Publishing.Infrastructure/HealthChecksExtensions.cs
+++ b/src/Publishing.Infrastructure/HealthChecksExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Publishing.Infrastructure;
+
+public static class HealthChecksExtensions
+{
+    public static IHealthChecksBuilder AddDatabaseHealthChecks(this IHealthChecksBuilder builder)
+    {
+        return builder.AddDbContextCheck<AppDbContext>("Database");
+    }
+}

--- a/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
+++ b/src/Publishing.Infrastructure/Publishing.Infrastructure.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
   </ItemGroup>
 
   <!-- Ensure EF Core migrations are compiled into the assembly -->

--- a/src/Publishing.Orders.Service/Extensions/SwaggerExtensions.cs
+++ b/src/Publishing.Orders.Service/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Publishing.Orders.Service.Extensions;
+
+public static class SwaggerExtensions
+{
+    public static IServiceCollection AddCustomSwagger(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(c =>
+        {
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header
+            });
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
+        });
+        return services;
+    }
+}

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -11,36 +11,12 @@ using OpenTelemetry.Trace;
 using MediatR;
 using Publishing.AppLayer.Handlers;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Publishing.Orders.Service.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = Microsoft.OpenApi.Models.SecuritySchemeType.Http,
-        Scheme = "bearer",
-        BearerFormat = "JWT",
-        In = Microsoft.OpenApi.Models.ParameterLocation.Header
-    });
-    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
-    {
-        {
-            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
-            {
-                Reference = new Microsoft.OpenApi.Models.OpenApiReference
-                {
-                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            Array.Empty<string>()
-        }
-    });
-});
+builder.Services.AddCustomSwagger();
 var redisConn = builder.Configuration["REDIS_CONN"];
 if (string.IsNullOrWhiteSpace(redisConn))
     throw new InvalidOperationException("REDIS_CONN environment variable is missing");
@@ -88,10 +64,15 @@ builder.Services.AddDbContext<AppDbContext>(o =>
 
 builder.Services
     .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>("Database");
+    .AddDatabaseHealthChecks();
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    await db.Database.MigrateAsync();
+}
 
 if (app.Environment.IsDevelopment())
 {
@@ -105,4 +86,4 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapHealthChecks("/health");
 
-app.Run();
+await app.RunAsync();

--- a/src/Publishing.Organization.Service/Extensions/SwaggerExtensions.cs
+++ b/src/Publishing.Organization.Service/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Publishing.Organization.Service.Extensions;
+
+public static class SwaggerExtensions
+{
+    public static IServiceCollection AddCustomSwagger(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(c =>
+        {
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header
+            });
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
+        });
+        return services;
+    }
+}

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -11,36 +11,12 @@ using System;
 using OpenTelemetry.Trace;
 using MediatR;
 using Publishing.AppLayer.Handlers;
+using Publishing.Organization.Service.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = SecuritySchemeType.Http,
-        Scheme = "bearer",
-        BearerFormat = "JWT",
-        In = ParameterLocation.Header
-    });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            Array.Empty<string>()
-        }
-    });
-});
+builder.Services.AddCustomSwagger();
 var redisConn = builder.Configuration["REDIS_CONN"];
 if (string.IsNullOrWhiteSpace(redisConn))
     throw new InvalidOperationException("REDIS_CONN environment variable is missing");
@@ -88,14 +64,14 @@ builder.Services.AddDbContext<AppDbContext>(o =>
 
 builder.Services
     .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>("Database");
+    .AddDatabaseHealthChecks();
 
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    db.Database.Migrate();
+    await db.Database.MigrateAsync();
 }
 
 if (app.Environment.IsDevelopment())
@@ -112,4 +88,4 @@ app.MapControllers();
 // Map health check endpoint so Docker can check container status
 app.MapHealthChecks("/health");
 
-app.Run();
+await app.RunAsync();

--- a/src/Publishing.Profile.Service/Extensions/SwaggerExtensions.cs
+++ b/src/Publishing.Profile.Service/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+namespace Publishing.Profile.Service.Extensions;
+
+public static class SwaggerExtensions
+{
+    public static IServiceCollection AddCustomSwagger(this IServiceCollection services)
+    {
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(c =>
+        {
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header
+            });
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
+        });
+        return services;
+    }
+}

--- a/src/tests/Publishing.Core.Tests/DatabaseInitializerTests.cs
+++ b/src/tests/Publishing.Core.Tests/DatabaseInitializerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Publishing.Infrastructure;
+using System.Threading.Tasks;
 
 namespace Publishing.Core.Tests
 {
@@ -8,7 +9,7 @@ namespace Publishing.Core.Tests
     public class DatabaseInitializerTests
     {
         [TestMethod]
-        public void InitializeAsync_WhenUpToDate_DoesNotThrow()
+        public async Task InitializeAsync_WhenUpToDate_DoesNotThrow()
         {
             var options = new DbContextOptionsBuilder<AppDbContext>()
                 .UseSqlite("DataSource=:memory:")
@@ -18,9 +19,9 @@ namespace Publishing.Core.Tests
             context.Database.OpenConnection();
             var initializer = new DatabaseInitializer(context);
 
-            initializer.InitializeAsync().GetAwaiter().GetResult();
+            await initializer.InitializeAsync();
             // Second call should not throw if the schema is already up to date.
-            initializer.InitializeAsync().GetAwaiter().GetResult();
+            await initializer.InitializeAsync();
         }
     }
 }

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -27,7 +27,7 @@ namespace Publishing.Integration.Tests
         private ServiceProvider _serviceProvider = null!;
 
         [TestInitialize]
-        public void Setup()
+        public async Task Setup()
         {
             _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingCrud_{Guid.NewGuid()}.db");
             if (File.Exists(_dbPath))
@@ -56,8 +56,8 @@ namespace Publishing.Integration.Tests
 
             _serviceProvider = services.BuildServiceProvider();
             using var scope = _serviceProvider.CreateScope();
-            scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
-                .InitializeAsync().Wait();
+            await scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
+                .InitializeAsync();
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
         }
 

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -25,7 +25,7 @@ namespace Publishing.Integration.Tests
         private ServiceProvider _serviceProvider = null!;
 
         [TestInitialize]
-        public void Setup()
+        public async Task Setup()
         {
             _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingTest_{Guid.NewGuid()}.db");
             if (File.Exists(_dbPath))
@@ -55,8 +55,8 @@ namespace Publishing.Integration.Tests
             _serviceProvider = services.BuildServiceProvider();
 
             using var scope = _serviceProvider.CreateScope();
-            scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
-                .InitializeAsync().Wait();
+            await scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
+                .InitializeAsync();
 
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
             _helper = scope.ServiceProvider.GetRequiredService<IDbHelper>();

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
+using System.Threading.Tasks;
 using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ namespace Publishing.Integration.Tests
         private ServiceProvider _serviceProvider = null!;
 
         [TestInitialize]
-        public void Setup()
+        public async Task Setup()
         {
             _dbPath = Path.Combine(Path.GetTempPath(), $"PublishingStat_{Guid.NewGuid()}.db");
             if (File.Exists(_dbPath))
@@ -53,8 +54,8 @@ namespace Publishing.Integration.Tests
             _serviceProvider = services.BuildServiceProvider();
 
             using var scope = _serviceProvider.CreateScope();
-            scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
-                .InitializeAsync().Wait();
+            await scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
+                .InitializeAsync();
             _db = scope.ServiceProvider.GetRequiredService<IDbContext>();
             _helper = scope.ServiceProvider.GetRequiredService<IDbHelper>();
 


### PR DESCRIPTION
## Summary
- convert migrations to use `MigrateAsync`
- expose Swagger only in development via extension method
- add reusable health check extension
- configure decimal precision for `Price` column
- explain environment variable usage in README
- make integration tests await `InitializeAsync`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `docker compose down -v` *(fails: `docker` not found)*
- `docker compose up --build -d` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685738a0f204832086e1ff34a76dc2cb