### PR TITLE
Add curl to service Dockerfiles

### DIFF
--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -18,8 +18,12 @@ RUN dotnet publish "ApiGateway.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------
 # 2) Runtime stage with ASP.NET Core Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/publish .
 

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -18,8 +18,12 @@ RUN dotnet publish "Publishing.Orders.Service.csproj" -c Release -o /app/publish
 
 # ------------------------------------------------------------
 # 2) Runtime stage with ASP.NET Core Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/publish .
 

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -18,8 +18,12 @@ RUN dotnet publish "Publishing.Organization.Service.csproj" -c Release -o /app/p
 
 # ------------------------------------------------------------
 # 2) Runtime stage with ASP.NET Core Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/publish .
 

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -18,8 +18,12 @@ RUN dotnet publish "Publishing.Profile.Service.csproj" -c Release -o /app/publis
 
 # ------------------------------------------------------------
 # 2) Runtime stage with ASP.NET Core Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/publish .
 


### PR DESCRIPTION
## Summary
- install curl in runtime images for ApiGateway and service containers

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857481b3ad08320b1db9c0bcd90fccc