### PR TITLE
Inject notifier into error handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,48 @@ jobs:
       run: dotnet build --no-restore
     - name: Format
       run: dotnet format --no-restore --verify-no-changes
+    - name: Analyzers
+      run: dotnet format analyzers --no-restore
+    - name: Grep for forbidden APIs
+      run: git grep -nE "(MessageBox\.Show|#if\s+WINDOWS)" && exit 1 || echo "OK"
     - name: Test
-      run: dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults /p:Threshold=80 /p:ThresholdType=line /p:ThresholdStat=total
+      run: dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults /p:Threshold=85 /p:ThresholdType=line /p:ThresholdStat=total
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -c Release
+    - name: Start WinAppDriver
+      shell: powershell
+      run: |
+        Start-Process "C:\\Program Files (x86)\\Windows Application Driver\\WinAppDriver.exe"
+        Start-Sleep -Seconds 5
+    - name: Test
+      run: dotnet test --no-build --results-directory ./TestResults
+    - uses: actions/upload-artifact@v3
+      with:
+        name: TestResults-windows
+        path: TestResults/*.trx
+
+  pack-analyzers:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Pack analyzers
+      run: dotnet pack src/Publishing.Analyzers/Publishing.Analyzers.csproj -c Release -o ./artifacts
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Publishing.Analyzers
+        path: artifacts/*.nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <ProjectReference Include="src/Publishing.Analyzers/Publishing.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/Publishing.sln
+++ b/Publishing.sln
@@ -25,6 +25,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Infrastructure",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Services", "src\Publishing.Services\Publishing.Services.csproj", "{FF727600-00AE-423C-BBDF-79CE9A936887}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.Analyzers", "src\Publishing.Analyzers\Publishing.Analyzers.csproj", "{AC103089-64AD-4B26-A15B-2F84A918CD25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Publishing.Analyzers.Tests", "src\tests\Publishing.Analyzers.Tests\Publishing.Analyzers.Tests.csproj", "{CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Publishing.UI.Tests", "src\tests\Publishing.UI.Tests\Publishing.UI.Tests.csproj", "{44E051FA-33A2-40AE-9F13-47D40DE71DBD}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publishing.AppLayer", "src\Publishing.Application\Publishing.Application.csproj", "{9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}"
 EndProject
 Global
@@ -56,7 +62,19 @@ Global
                 {FF727600-00AE-423C-BBDF-79CE9A936887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
                 {FF727600-00AE-423C-BBDF-79CE9A936887}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {FF727600-00AE-423C-BBDF-79CE9A936887}.Release|Any CPU.ActiveCfg = Release|Any CPU
-               {FF727600-00AE-423C-BBDF-79CE9A936887}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FF727600-00AE-423C-BBDF-79CE9A936887}.Release|Any CPU.Build.0 = Release|Any CPU
+                {AC103089-64AD-4B26-A15B-2F84A918CD25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {AC103089-64AD-4B26-A15B-2F84A918CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {AC103089-64AD-4B26-A15B-2F84A918CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {AC103089-64AD-4B26-A15B-2F84A918CD25}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {44E051FA-33A2-40AE-9F13-47D40DE71DBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {44E051FA-33A2-40AE-9F13-47D40DE71DBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {44E051FA-33A2-40AE-9F13-47D40DE71DBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {44E051FA-33A2-40AE-9F13-47D40DE71DBD}.Release|Any CPU.Build.0 = Release|Any CPU
                 {9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
                 {9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {9B9E0E43-9D97-4EC5-90DF-5FF262EE6237}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -73,7 +91,10 @@ Global
                 {5BEE1912-C60A-4659-A148-167B511A7FB2} = {9FCB158E-82F3-4656-90C3-45A54BFB864D}
                 {231CAED0-18C1-49D4-8FED-53712F50F9DE} = {9FCB158E-82F3-4656-90C3-45A54BFB864D}
                 {FF727600-00AE-423C-BBDF-79CE9A936887} = {9FCB158E-82F3-4656-90C3-45A54BFB864D}
+                {AC103089-64AD-4B26-A15B-2F84A918CD25} = {9FCB158E-82F3-4656-90C3-45A54BFB864D}
                 {9B9E0E43-9D97-4EC5-90DF-5FF262EE6237} = {9FCB158E-82F3-4656-90C3-45A54BFB864D}
+                {CE5E9BC3-FA99-48FA-9D32-A5CFD407FFAA} = {FFA3015B-5245-4B86-951B-1D94EF3D19E3}
+                {44E051FA-33A2-40AE-9F13-47D40DE71DBD} = {FFA3015B-5245-4B86-951B-1D94EF3D19E3}
         EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4C64FC7B-E529-436C-853E-F7D353E38210}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
+      - NOTIFICATIONS_DISABLED=true
     depends_on:
       db:
         condition: service_healthy
@@ -42,6 +43,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
+      - NOTIFICATIONS_DISABLED=true
     depends_on:
       db:
         condition: service_healthy
@@ -71,6 +73,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
+      - NOTIFICATIONS_DISABLED=true
     depends_on:
       db:
         condition: service_healthy
@@ -98,6 +101,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
+      - NOTIFICATIONS_DISABLED=true
     depends_on:
       orders:
         condition: service_healthy

--- a/docs/ui-testing.md
+++ b/docs/ui-testing.md
@@ -1,0 +1,20 @@
+# UI Testing
+
+WinForms screens are tested using WinAppDriver. Install the driver from the official site and start it before running the tests.
+
+```powershell
+WinAppDriver.exe
+```
+
+Example test checking for a balloon tip:
+
+```csharp
+var session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), caps);
+// ... click the Create button
+var notification = session.FindElementByName("Publishing");
+Assert.IsNotNull(notification);
+```
+
+These tests run only on Windows agents. In GitHub Actions the `windows-latest` job runs them automatically.
+
+Screenshots are saved to `TestResults/screenshots` and uploaded as workflow artifacts. Set `NOTIFICATIONS_DISABLED=false` when debugging locally so balloon tips appear.

--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddAuthentication("Bearer")
         };
     });
 builder.Services.AddAuthorization();
+builder.Services.AddUiNotifier();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IJwtFactory, JwtFactory>();

--- a/src/Publishing.Analyzers/AddUiNotifierAnalyzer.cs
+++ b/src/Publishing.Analyzers/AddUiNotifierAnalyzer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Publishing.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AddUiNotifierAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "PUB001";
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "AddUiNotifier missing",
+        "services.AddUiNotifier() is not called",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        context.RegisterSyntaxNodeAction(AnalyzeProgram, SyntaxKind.CompilationUnit);
+    }
+
+    private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+    {
+        var method = (MethodDeclarationSyntax)context.Node;
+        if (method.Identifier.Text != "ConfigureServices")
+            return;
+
+        if (!CallsAddUiNotifier(method, context.SemanticModel))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation()));
+        }
+    }
+
+    private static void AnalyzeProgram(SyntaxNodeAnalysisContext context)
+    {
+        var root = (CompilationUnitSyntax)context.Node;
+        if (!CallsAddUiNotifier(root, context.SemanticModel))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, root.GetLocation()));
+        }
+    }
+
+    private static bool CallsAddUiNotifier(SyntaxNode node, SemanticModel model)
+    {
+        foreach (var invocation in node.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var symbol = model.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+            if (symbol == null)
+                continue;
+            if (symbol.Name == "AddUiNotifier")
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
+++ b/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Publishing.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ForbiddenApiAnalyzer : DiagnosticAnalyzer
+{
+    public const string MessageBoxId = "PUB002";
+    public const string WindowsDirectiveId = "PUB003";
+
+    private static readonly DiagnosticDescriptor MessageBoxRule = new(
+        MessageBoxId,
+        "MessageBox.Show usage",
+        "Do not use MessageBox.Show; use IUiNotifier",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor WindowsRule = new(
+        WindowsDirectiveId,
+        "#if WINDOWS usage",
+        "Do not use #if WINDOWS conditional compilation",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(MessageBoxRule, WindowsRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxTreeAction(AnalyzeTree);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is InvocationExpressionSyntax inv)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(inv).Symbol as IMethodSymbol;
+            if (symbol?.ContainingType?.ToDisplayString() == "System.Windows.Forms.MessageBox" && symbol.Name == "Show")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MessageBoxRule, inv.GetLocation()));
+            }
+        }
+    }
+
+    private static void AnalyzeTree(SyntaxTreeAnalysisContext context)
+    {
+        var root = context.Tree.GetRoot(context.CancellationToken);
+        foreach (var directive in root.DescendantTrivia().Where(t => t.IsKind(SyntaxKind.IfDirectiveTrivia)))
+        {
+            var ifDir = (IfDirectiveTriviaSyntax)directive.GetStructure();
+            if (ifDir != null && ifDir.Condition.ToString().Contains("WINDOWS"))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(WindowsRule, directive.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+</Project>

--- a/src/Publishing.Application/Handlers/CreateOrderHandler.cs
+++ b/src/Publishing.Application/Handlers/CreateOrderHandler.cs
@@ -8,6 +8,7 @@ using Publishing.Core.Interfaces;
 using FluentValidation;
 using Publishing.Services.Events;
 using AutoMapper;
+using System.Resources;
 
 namespace Publishing.AppLayer.Handlers
 {
@@ -21,6 +22,8 @@ namespace Publishing.AppLayer.Handlers
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IUnitOfWork _unitOfWork;
         private readonly IOrderEventsPublisher _events;
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _resources = new("Publishing.Services.Resources.Notifications", typeof(CreateOrderHandler).Assembly);
 
         public CreateOrderHandler(
             IOrderRepository orderRepository,
@@ -30,7 +33,8 @@ namespace Publishing.AppLayer.Handlers
             IMapper mapper,
             IDateTimeProvider dateTimeProvider,
             IUnitOfWork unitOfWork,
-            IOrderEventsPublisher events)
+            IOrderEventsPublisher events,
+            IUiNotifier notifier)
         {
             _orderRepository = orderRepository;
             _printeryRepository = printeryRepository;
@@ -39,6 +43,7 @@ namespace Publishing.AppLayer.Handlers
             _dateTimeProvider = dateTimeProvider;
             _unitOfWork = unitOfWork;
             _events = events;
+            _notifier = notifier;
             _mapper = mapper;
         }
 
@@ -53,6 +58,7 @@ namespace Publishing.AppLayer.Handlers
             await SaveOrderAsync(order);
             var dto = _mapper.Map<Publishing.Core.DTOs.OrderDto>(order);
             _events.PublishOrderCreated(dto);
+            _notifier.NotifyInfo(_resources.GetString("OrderCreated") ?? "Order created");
 
             return order;
         }

--- a/src/Publishing.Application/Handlers/UpdateOrganizationHandler.cs
+++ b/src/Publishing.Application/Handlers/UpdateOrganizationHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using FluentValidation;
 using Publishing.Core.Commands;
 using Publishing.Core.Interfaces;
+using System.Resources;
 
 namespace Publishing.AppLayer.Handlers;
 
@@ -13,12 +14,15 @@ public class UpdateOrganizationHandler : IRequestHandler<UpdateOrganizationComma
     private readonly IOrganizationRepository _repo;
     private readonly IValidator<UpdateOrganizationCommand> _validator;
     private readonly IUnitOfWork _uow;
+    private readonly IUiNotifier _notifier;
+    private readonly ResourceManager _resources = new("Publishing.Services.Resources.Notifications", typeof(UpdateOrganizationHandler).Assembly);
 
-    public UpdateOrganizationHandler(IOrganizationRepository repo, IValidator<UpdateOrganizationCommand> validator, IUnitOfWork uow)
+    public UpdateOrganizationHandler(IOrganizationRepository repo, IValidator<UpdateOrganizationCommand> validator, IUnitOfWork uow, IUiNotifier notifier)
     {
         _repo = repo;
         _validator = validator;
         _uow = uow;
+        _notifier = notifier;
     }
 
     public async Task<Unit> Handle(UpdateOrganizationCommand request, CancellationToken cancellationToken)
@@ -46,6 +50,7 @@ public class UpdateOrganizationHandler : IRequestHandler<UpdateOrganizationComma
                 await _repo.InsertAsync(createCmd).ConfigureAwait(false);
             }
             await _uow.CommitAsync();
+            _notifier.NotifyInfo(_resources.GetString("OrganizationUpdated") ?? "Organization updated");
         }
         catch
         {

--- a/src/Publishing.Application/Handlers/UpdateProfileHandler.cs
+++ b/src/Publishing.Application/Handlers/UpdateProfileHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using FluentValidation;
 using Publishing.Core.Commands;
 using Publishing.Core.Interfaces;
+using System.Resources;
 
 namespace Publishing.AppLayer.Handlers;
 
@@ -13,12 +14,15 @@ public class UpdateProfileHandler : IRequestHandler<UpdateProfileCommand>
     private readonly IProfileRepository _repo;
     private readonly IValidator<UpdateProfileCommand> _validator;
     private readonly IUnitOfWork _uow;
+    private readonly IUiNotifier _notifier;
+    private readonly ResourceManager _resources = new("Publishing.Services.Resources.Notifications", typeof(UpdateProfileHandler).Assembly);
 
-    public UpdateProfileHandler(IProfileRepository repo, IValidator<UpdateProfileCommand> validator, IUnitOfWork uow)
+    public UpdateProfileHandler(IProfileRepository repo, IValidator<UpdateProfileCommand> validator, IUnitOfWork uow, IUiNotifier notifier)
     {
         _repo = repo;
         _validator = validator;
         _uow = uow;
+        _notifier = notifier;
     }
 
     public async Task<Unit> Handle(UpdateProfileCommand request, CancellationToken cancellationToken)
@@ -33,6 +37,7 @@ public class UpdateProfileHandler : IRequestHandler<UpdateProfileCommand>
             }
             await _repo.UpdateAsync(request).ConfigureAwait(false);
             await _uow.CommitAsync();
+            _notifier.NotifyInfo(_resources.GetString("ProfileUpdated") ?? "Profile updated");
             return Unit.Value;
         }
         catch

--- a/src/Publishing.Application/Publishing.Application.csproj
+++ b/src/Publishing.Application/Publishing.Application.csproj
@@ -13,5 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
+    <ProjectReference Include="../Publishing.Services/Publishing.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -80,6 +80,7 @@ builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
 builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddUiNotifier();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IJwtFactory, JwtFactory>();

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
 builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddUiNotifier();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IJwtFactory, JwtFactory>();

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
 builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddUiNotifier();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IJwtFactory, JwtFactory>();

--- a/src/Publishing.Services/ErrorHandling/ErrorHandler.cs
+++ b/src/Publishing.Services/ErrorHandling/ErrorHandler.cs
@@ -1,6 +1,3 @@
-#if WINDOWS
-using System.Windows.Forms;
-#endif
 using System;
 using Publishing.Core.Interfaces;
 
@@ -9,27 +6,26 @@ namespace Publishing.Services
     public class ErrorHandler : IErrorHandler
     {
         private readonly ILogger _logger;
+        private readonly IUiNotifier _notifier;
 
-        public ErrorHandler(ILogger logger)
+        public ErrorHandler(ILogger logger, IUiNotifier notifier)
         {
             _logger = logger;
+            _notifier = notifier;
         }
 
         public void Handle(Exception ex)
         {
             _logger.LogError(ex.Message, ex);
-#if WINDOWS
-            MessageBox.Show(ex.Message, "Помилка");
-#endif
+            try
+            {
+                _notifier.NotifyError(ex.Message, ex.StackTrace);
+            }
+            catch
+            {
+                // ignore notifier failures
+            }
         }
 
-        public void ShowFriendlyError(string message)
-        {
-#if WINDOWS
-            MessageBox.Show(message, "Помилка");
-#else
-            _logger.LogInformation(message);
-#endif
-        }
     }
 }

--- a/src/Publishing.Services/ErrorHandling/IErrorHandler.cs
+++ b/src/Publishing.Services/ErrorHandling/IErrorHandler.cs
@@ -3,6 +3,5 @@ namespace Publishing.Services
     public interface IErrorHandler
     {
         void Handle(System.Exception ex);
-        void ShowFriendlyError(string message);
     }
 }

--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -6,10 +6,16 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <Compile Include="UiNotifications/WinFormsUiNotifier.cs" />
+    <Compile Include="ServiceCollectionExtensions.Windows.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.31.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='net6.0-windows'">
+    <Compile Remove="UiNotifications/WinFormsUiNotifier.cs" />
+    <Compile Remove="ServiceCollectionExtensions.Windows.cs" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Services/Resources/Notifications.en-US.resx
+++ b/src/Publishing.Services/Resources/Notifications.en-US.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="OrderCreated" xml:space="preserve">
+    <value>Order created</value>
+  </data>
+  <data name="OrganizationUpdated" xml:space="preserve">
+    <value>Organization updated</value>
+  </data>
+  <data name="ProfileUpdated" xml:space="preserve">
+    <value>Profile updated</value>
+  </data>
+  <data name="OrderDeleted" xml:space="preserve">
+    <value>Deleted order {0}</value>
+  </data>
+  <data name="InvalidCredentials" xml:space="preserve">
+    <value>Invalid email or password</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Welcome, {0} ({1})!</value>
+  </data>
+</root>

--- a/src/Publishing.Services/Resources/Notifications.resx
+++ b/src/Publishing.Services/Resources/Notifications.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="OrderCreated" xml:space="preserve">
+    <value>Order created</value>
+  </data>
+  <data name="OrganizationUpdated" xml:space="preserve">
+    <value>Organization updated</value>
+  </data>
+  <data name="ProfileUpdated" xml:space="preserve">
+    <value>Profile updated</value>
+  </data>
+  <data name="OrderDeleted" xml:space="preserve">
+    <value>Deleted order {0}</value>
+  </data>
+  <data name="InvalidCredentials" xml:space="preserve">
+    <value>Invalid email or password</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Welcome, {0} ({1})!</value>
+  </data>
+</root>

--- a/src/Publishing.Services/Resources/Notifications.uk-UA.resx
+++ b/src/Publishing.Services/Resources/Notifications.uk-UA.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="OrderCreated" xml:space="preserve">
+    <value>Замовлення створено</value>
+  </data>
+  <data name="OrganizationUpdated" xml:space="preserve">
+    <value>Організацію оновлено</value>
+  </data>
+  <data name="ProfileUpdated" xml:space="preserve">
+    <value>Профіль оновлено</value>
+  </data>
+  <data name="OrderDeleted" xml:space="preserve">
+    <value>Видалено замовлення № {0}</value>
+  </data>
+  <data name="InvalidCredentials" xml:space="preserve">
+    <value>Невірна електронна пошта або пароль</value>
+  </data>
+  <data name="WelcomeUser" xml:space="preserve">
+    <value>Вітаємо, {0} ({1})!</value>
+  </data>
+</root>

--- a/src/Publishing.Services/ServiceCollectionExtensions.NonWindows.cs
+++ b/src/Publishing.Services/ServiceCollectionExtensions.NonWindows.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Publishing.Services
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        static partial void AddUiNotifierPlatform(IServiceCollection services)
+        {
+            services.AddSingleton<IUiNotifier, ConsoleUiNotifier>();
+        }
+    }
+}

--- a/src/Publishing.Services/ServiceCollectionExtensions.Windows.cs
+++ b/src/Publishing.Services/ServiceCollectionExtensions.Windows.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Publishing.Services
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        static partial void AddUiNotifierPlatform(IServiceCollection services)
+        {
+            services.AddSingleton<IUiNotifier, WinFormsUiNotifier>();
+        }
+    }
+}

--- a/src/Publishing.Services/ServiceCollectionExtensions.cs
+++ b/src/Publishing.Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Publishing.Services
+{
+    public static partial class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddUiNotifier(this IServiceCollection services)
+        {
+            var disabled = Environment.GetEnvironmentVariable("NOTIFICATIONS_DISABLED");
+            if (string.Equals(disabled, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                services.AddSingleton<IUiNotifier, SilentUiNotifier>();
+                return services;
+            }
+
+            AddUiNotifierPlatform(services);
+            return services;
+        }
+
+        static partial void AddUiNotifierPlatform(IServiceCollection services);
+    }
+}

--- a/src/Publishing.Services/UiNotifications/ConsoleUiNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/ConsoleUiNotifier.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Publishing.Services
+{
+    public class ConsoleUiNotifier : IUiNotifier
+    {
+        private readonly bool _useColor = !Console.IsOutputRedirected && Environment.GetEnvironmentVariable("CI") != "true";
+
+        public void NotifyInfo(string message)
+        {
+            Write("INFO", message, ConsoleColor.White);
+        }
+
+        public void NotifyWarning(string message)
+        {
+            Write("WARN", message, ConsoleColor.Yellow);
+        }
+
+        public void NotifyError(string message, string? details = null)
+        {
+            Write("ERROR", message, ConsoleColor.Red);
+            if (!string.IsNullOrEmpty(details))
+            {
+                var truncated = details.Length > 120 ? details[..120] + "..." : details;
+                Console.WriteLine(truncated);
+            }
+        }
+
+        private void Write(string prefix, string message, ConsoleColor color)
+        {
+            if (_useColor)
+            {
+                var previous = Console.ForegroundColor;
+                Console.ForegroundColor = color;
+                Console.WriteLine($"{prefix}: {message}");
+                Console.ForegroundColor = previous;
+            }
+            else
+            {
+                Console.WriteLine($"{prefix}: {message}");
+            }
+        }
+    }
+}

--- a/src/Publishing.Services/UiNotifications/IUiNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/IUiNotifier.cs
@@ -1,0 +1,9 @@
+namespace Publishing.Services
+{
+    public interface IUiNotifier
+    {
+        void NotifyInfo(string message);
+        void NotifyWarning(string message);
+        void NotifyError(string message, string? details = null);
+    }
+}

--- a/src/Publishing.Services/UiNotifications/SilentUiNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/SilentUiNotifier.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Publishing.Services
+{
+    public class SilentUiNotifier : IUiNotifier
+    {
+        public void NotifyInfo(string message) { }
+        public void NotifyWarning(string message) { }
+        public void NotifyError(string message, string? details = null) { }
+    }
+}

--- a/src/Publishing.Services/UiNotifications/WinFormsUiNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/WinFormsUiNotifier.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Windows.Forms;
+
+namespace Publishing.Services
+{
+    public class WinFormsUiNotifier : IUiNotifier, IDisposable
+    {
+        private readonly NotifyIcon _notifyIcon;
+
+        public WinFormsUiNotifier()
+        {
+            _notifyIcon = new NotifyIcon
+            {
+                Visible = true,
+                Icon = System.Drawing.SystemIcons.Information
+            };
+        }
+
+        public void NotifyInfo(string message)
+        {
+            Show(message, ToolTipIcon.Info);
+        }
+
+        public void NotifyWarning(string message)
+        {
+            Show(message, ToolTipIcon.Warning);
+        }
+
+        public void NotifyError(string message, string? details = null)
+        {
+            if (!string.IsNullOrEmpty(details))
+            {
+                try { Clipboard.SetText(details); } catch { /* ignore */ }
+            }
+            Show(message, ToolTipIcon.Error);
+        }
+
+        private void Show(string message, ToolTipIcon icon)
+        {
+            _notifyIcon.BalloonTipTitle = "Publishing";
+            _notifyIcon.BalloonTipText = message;
+            _notifyIcon.BalloonTipIcon = icon;
+            _notifyIcon.ShowBalloonTip(3000);
+        }
+
+        public void Dispose()
+        {
+            _notifyIcon.Dispose();
+        }
+    }
+}

--- a/src/Publishing.UI/Forms/addOrderForm.Designer.cs
+++ b/src/Publishing.UI/Forms/addOrderForm.Designer.cs
@@ -130,7 +130,7 @@
             this.totalPriceLabel.Name = "totalPriceLabel";
             this.totalPriceLabel.Size = new System.Drawing.Size(105, 20);
             this.totalPriceLabel.TabIndex = 32;
-            this.totalPriceLabel.Text = "Кінцева ціна:";
+            this.totalPriceLabel.Text = "Total price:";
             // 
             // tirageTextBox
             // 

--- a/src/Publishing.UI/Forms/deleteOrderForm.cs
+++ b/src/Publishing.UI/Forms/deleteOrderForm.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
 using System.Threading.Tasks;
-using Publishing.Services.ErrorHandling;
+using System.Resources;
 
 namespace Publishing
 {
@@ -12,7 +12,8 @@ namespace Publishing
     {
         private readonly IOrderRepository _orderRepo;
         private readonly IRoleService _roles;
-        private readonly IErrorHandler _errorHandler;
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _notify = new("Publishing.Services.Resources.Notifications", typeof(deleteOrderForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public deleteOrderForm()
@@ -20,12 +21,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public deleteOrderForm(INavigationService navigation, IOrderRepository orderRepo, IUserSession session, IRoleService roles, IErrorHandler errorHandler)
+        public deleteOrderForm(INavigationService navigation, IOrderRepository orderRepo, IUserSession session, IRoleService roles, IUiNotifier notifier)
             : base(session, navigation)
         {
             _orderRepo = orderRepo;
             _roles = roles;
-            _errorHandler = errorHandler;
+            _notifier = notifier;
             InitializeComponent();
         }
 
@@ -37,7 +38,7 @@ namespace Publishing
 
                 await _orderRepo.DeleteAsync(idToDelete);
 
-                _errorHandler.ShowFriendlyError("Видалено idOrder: " + idToDelete.ToString());
+                _notifier.NotifyInfo(string.Format(_notify.GetString("OrderDeleted") ?? "Deleted order {0}", idToDelete));
 
                 dataGridView1.Rows.RemoveAt(e.RowIndex);
             }

--- a/src/Publishing.UI/Forms/loginForm.cs
+++ b/src/Publishing.UI/Forms/loginForm.cs
@@ -1,7 +1,7 @@
 using System;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
-using Publishing.Services.ErrorHandling;
+using System.Resources;
 using System.Windows.Forms;
 
 namespace Publishing
@@ -9,7 +9,8 @@ namespace Publishing
     public partial class loginForm : BaseForm
     {
         private readonly IAuthService _authService;
-        private readonly IErrorHandler _errorHandler;
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _notify = new("Publishing.Services.Resources.Notifications", typeof(loginForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public loginForm()
@@ -17,11 +18,11 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public loginForm(IAuthService authService, INavigationService navigation, IUserSession session, IErrorHandler errorHandler)
+        public loginForm(IAuthService authService, INavigationService navigation, IUserSession session, IUiNotifier notifier)
             : base(session, navigation)
         {
             _authService = authService;
-            _errorHandler = errorHandler;
+            _notifier = notifier;
             InitializeComponent();
         }
 
@@ -41,11 +42,11 @@ namespace Publishing
                 _session.Token = result.Token;
 
                 _navigation.Navigate<mainForm>(this);
-                _errorHandler.ShowFriendlyError($"Вітаємо, {_session.UserName} ({_session.UserType})!");
+                _notifier.NotifyInfo(string.Format(_notify.GetString("WelcomeUser") ?? "Welcome, {0}!", _session.UserName, _session.UserType));
             }
             else
             {
-                _errorHandler.ShowFriendlyError("Невірна електронна пошта або пароль");
+                _notifier.NotifyWarning(_notify.GetString("InvalidCredentials") ?? "Invalid credentials");
             }
         }
 

--- a/src/Publishing.UI/Forms/mainForm.cs
+++ b/src/Publishing.UI/Forms/mainForm.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Windows.Forms;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
+using Publishing.Services.ErrorHandling;
 using System.Threading.Tasks;
 
 namespace Publishing
@@ -11,6 +12,7 @@ namespace Publishing
     {
         private readonly IOrderRepository _orderRepo;
         private readonly IRoleService _roles;
+        private readonly IErrorHandler _errorHandler;
 
         [Obsolete("Designer only", error: false)]
         public mainForm()
@@ -18,11 +20,17 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public mainForm(INavigationService navigation, IOrderRepository orderRepo, IUserSession session, IRoleService roles)
+        public mainForm(
+            INavigationService navigation,
+            IOrderRepository orderRepo,
+            IUserSession session,
+            IRoleService roles,
+            IErrorHandler errorHandler)
             : base(session, navigation)
         {
             _orderRepo = orderRepo;
             _roles = roles;
+            _errorHandler = errorHandler;
             InitializeComponent();
         }
 
@@ -71,10 +79,16 @@ namespace Publishing
                 змінитиДаніToolStripMenuItem.Visible = true;
             }
 
-            await _orderRepo.UpdateExpiredAsync();
-            DataTable dataTable = await _orderRepo.GetActiveAsync();
-
-            dataGridView1.DataSource = dataTable;
+            try
+            {
+                await _orderRepo.UpdateExpiredAsync();
+                DataTable dataTable = await _orderRepo.GetActiveAsync();
+                dataGridView1.DataSource = dataTable;
+            }
+            catch (Exception ex)
+            {
+                _errorHandler.Handle(ex);
+            }
         }
 
         private void статистикаToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/Publishing.UI/Forms/organizationForm.cs
+++ b/src/Publishing.UI/Forms/organizationForm.cs
@@ -5,7 +5,6 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.DTOs;
 using System.Resources;
 using System.Threading.Tasks;
-using Publishing.Services.ErrorHandling;
 
 namespace Publishing
 {
@@ -13,8 +12,9 @@ namespace Publishing
     {
         private readonly IOrganizationService _service;
         private readonly IRoleService _roles;
-        private readonly IErrorHandler _errorHandler;
-        private readonly ResourceManager _resources = new ResourceManager("Publishing.Resources.Resources", typeof(organizationForm).Assembly);
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _resources = new("Publishing.Resources.Resources", typeof(organizationForm).Assembly);
+        private readonly ResourceManager _notify = new("Publishing.Services.Resources.Notifications", typeof(organizationForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public organizationForm()
@@ -22,12 +22,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public organizationForm(INavigationService navigation, IOrganizationService service, IUserSession session, IRoleService roles, IErrorHandler errorHandler)
+        public organizationForm(INavigationService navigation, IOrganizationService service, IUserSession session, IRoleService roles, IUiNotifier notifier)
             : base(session, navigation)
         {
             _service = service;
             _roles = roles;
-            _errorHandler = errorHandler;
+            _notifier = notifier;
             InitializeComponent();
         }
 
@@ -54,7 +54,7 @@ namespace Publishing
             };
 
             await _service.UpdateAsync(dto);
-            _errorHandler.ShowFriendlyError(_resources.GetString("DataUpdated") ?? "Success");
+            _notifier.NotifyInfo(_notify.GetString("OrganizationUpdated") ?? "Success");
             _navigation.Navigate<mainForm>(this);
         }
 

--- a/src/Publishing.UI/Forms/profileForm.cs
+++ b/src/Publishing.UI/Forms/profileForm.cs
@@ -5,7 +5,6 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.DTOs;
 using System.Resources;
 using System.Threading.Tasks;
-using Publishing.Services.ErrorHandling;
 
 namespace Publishing
 {
@@ -13,8 +12,8 @@ namespace Publishing
     {
         private readonly IProfileService _profileService;
         private readonly IRoleService _roles;
-        private readonly IErrorHandler _errorHandler;
-        private readonly ResourceManager _resources = new ResourceManager("Publishing.Resources.Resources", typeof(profileForm).Assembly);
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _notify = new("Publishing.Services.Resources.Notifications", typeof(profileForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public profileForm()
@@ -22,12 +21,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public profileForm(INavigationService navigation, IProfileService profileService, IUserSession session, IRoleService roles, IErrorHandler errorHandler)
+        public profileForm(INavigationService navigation, IProfileService profileService, IUserSession session, IRoleService roles, IUiNotifier notifier)
             : base(session, navigation)
         {
             _profileService = profileService;
             _roles = roles;
-            _errorHandler = errorHandler;
+            _notifier = notifier;
             InitializeComponent();
         }
 
@@ -51,7 +50,7 @@ namespace Publishing
             };
 
             await _profileService.UpdateAsync(dto);
-            _errorHandler.ShowFriendlyError(_resources.GetString("DataUpdated") ?? "Success");
+            _notifier.NotifyInfo(_notify.GetString("ProfileUpdated") ?? "Success");
             _navigation.Navigate<mainForm>(this);
         }
 

--- a/src/Publishing.UI/Forms/registrationForm.cs
+++ b/src/Publishing.UI/Forms/registrationForm.cs
@@ -6,6 +6,7 @@ using Publishing.Core.DTOs;
 using Publishing.Services;
 using Publishing.Services.ErrorHandling;
 using System.Threading.Tasks;
+using System.Resources;
 
 namespace Publishing
 {
@@ -13,6 +14,8 @@ namespace Publishing
     {
         private readonly IRegistrationService _service;
         private readonly IErrorHandler _errorHandler;
+        private readonly IUiNotifier _notifier;
+        private readonly ResourceManager _notify = new("Publishing.Services.Resources.Notifications", typeof(registrationForm).Assembly);
 
         [Obsolete("Designer only", error: false)]
         public registrationForm()
@@ -20,11 +23,12 @@ namespace Publishing
             InitializeComponent();
         }
 
-        public registrationForm(IRegistrationService service, INavigationService navigation, IUserSession session, IErrorHandler errorHandler)
+        public registrationForm(IRegistrationService service, INavigationService navigation, IUserSession session, IErrorHandler errorHandler, IUiNotifier notifier)
             : base(session, navigation)
         {
             _service = service;
             _errorHandler = errorHandler;
+            _notifier = notifier;
             InitializeComponent();
         }
 
@@ -54,7 +58,7 @@ namespace Publishing
                 _session.Token = result.Token;
 
                 _navigation.Navigate<mainForm>(this);
-                _errorHandler.ShowFriendlyError($"Вітаємо, {_session.UserName} ({_session.UserType})!");
+                _notifier.NotifyInfo(string.Format(_notify.GetString("WelcomeUser") ?? "Welcome, {0}!", _session.UserName, _session.UserType));
             }
             catch (Exception ex)
             {

--- a/src/Publishing.UI/Navigation/INavigationService.cs
+++ b/src/Publishing.UI/Navigation/INavigationService.cs
@@ -1,12 +1,9 @@
-#if WINDOWS
+using System.Windows.Forms;
+
 namespace Publishing.Services
 {
-    using System;
-    using System.Windows.Forms;
-
     public interface INavigationService
     {
         void Navigate<T>(Form current) where T : Form;
     }
 }
-#endif

--- a/src/Publishing.UI/Navigation/NavigationService.cs
+++ b/src/Publishing.UI/Navigation/NavigationService.cs
@@ -1,10 +1,9 @@
-#if WINDOWS
+using System;
+using System.Windows.Forms;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Publishing.Services
 {
-    using System;
-    using System.Windows.Forms;
-    using Microsoft.Extensions.DependencyInjection;
-
     public class NavigationService : INavigationService
     {
         private readonly IServiceProvider _provider;
@@ -22,4 +21,3 @@ namespace Publishing.Services
         }
     }
 }
-#endif

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -39,6 +39,9 @@ namespace Publishing
 
 
 
+            var notifier = Services.GetRequiredService<IUiNotifier>() as IDisposable;
+            System.Windows.Forms.Application.ApplicationExit += (_, __) => notifier?.Dispose();
+
             var form = Services.GetRequiredService<loginForm>();
             System.Windows.Forms.Application.Run(form);
 
@@ -65,6 +68,7 @@ namespace Publishing
             services.AddScoped<IPriceCalculator, PriceCalculator>();
             services.AddScoped<IOrderInputValidator, OrderInputValidator>();
             services.AddScoped<IRoleService, RoleService>();
+            services.AddUiNotifier();
             services.AddScoped<IErrorHandler, ErrorHandler>();
             services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
             services.AddSingleton<IUserSession, UserSession>();

--- a/src/Publishing.UI/Resources/Resources.en.resx
+++ b/src/Publishing.UI/Resources/Resources.en.resx
@@ -12,4 +12,7 @@
   <data name="DataUpdated" xml:space="preserve">
     <value>Data successfully updated</value>
   </data>
+  <data name="TotalPriceLabel" xml:space="preserve">
+    <value>Total price: {0}</value>
+  </data>
 </root>

--- a/src/Publishing.UI/Resources/Resources.resx
+++ b/src/Publishing.UI/Resources/Resources.resx
@@ -12,4 +12,7 @@
   <data name="DataUpdated" xml:space="preserve">
     <value>Дані успішно змінено</value>
   </data>
+  <data name="TotalPriceLabel" xml:space="preserve">
+    <value>Кінцева ціна: {0}</value>
+  </data>
 </root>

--- a/src/Publishing.UI/Resources/Resources.uk.resx
+++ b/src/Publishing.UI/Resources/Resources.uk.resx
@@ -12,4 +12,7 @@
   <data name="DataUpdated" xml:space="preserve">
     <value>Дані успішно змінено</value>
   </data>
+  <data name="TotalPriceLabel" xml:space="preserve">
+    <value>Кінцева ціна: {0}</value>
+  </data>
 </root>

--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -1,0 +1,80 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.CSharp;
+using Publishing.Analyzers;
+
+namespace Publishing.Analyzers.Tests;
+
+[TestClass]
+public class AnalyzerTests
+{
+    private static async Task VerifyAsync<T>(string source) where T : DiagnosticAnalyzer, new()
+    {
+        var test = new CSharpAnalyzerTest<T, MSTestVerifier>
+        {
+            TestCode = source,
+        };
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task ConfigureServicesWithoutCall_ProducesWarning()
+    {
+        var code = @"using Microsoft.Extensions.DependencyInjection;\nclass Startup{void ConfigureServices(IServiceCollection s){}}";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task ConfigureServicesWithCall_NoWarning()
+    {
+        var code = @"using Microsoft.Extensions.DependencyInjection;\nclass Startup{void ConfigureServices(IServiceCollection s){s.AddUiNotifier();}}";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task ProgramWithoutCall_ProducesDiagnostic()
+    {
+        var code = "using Microsoft.Extensions.DependencyInjection;\nvar builder = WebApplication.CreateBuilder();";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task MessageBoxShow_ProducesDiagnostic()
+    {
+        var code = "using System.Windows.Forms; class C{ void M(){ MessageBox.Show(\"x\");}}";
+        await VerifyAsync<ForbiddenApiAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task BuilderServicesVariable_NoDiagnostic()
+    {
+        var code = @"using Microsoft.Extensions.DependencyInjection;
+var builder = WebApplication.CreateBuilder();
+var svcs = builder.Services;
+svcs.AddLogging();
+svcs.AddUiNotifier();";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task MissingInChainedSetup_ProducesDiagnostic()
+    {
+        var code = @"using Microsoft.Extensions.DependencyInjection;
+class Startup{void ConfigureServices(IServiceCollection s){s
+    .AddLogging()
+    .AddRouting();}}";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+
+    [TestMethod]
+    public async Task ExtensionMethodRegistration_NoDiagnostic()
+    {
+        var code = @"using Microsoft.Extensions.DependencyInjection;
+static class Ext{public static void Reg(this IServiceCollection s){s.AddUiNotifier();}}
+class S{void ConfigureServices(IServiceCollection s){s.Reg();}}";
+        await VerifyAsync<AddUiNotifierAnalyzer>(code);
+    }
+}

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.2.0-beta1.23556.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Publishing.Analyzers/Publishing.Analyzers.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Publishing.Core.Tests/ConsoleUiNotifierTests.cs
+++ b/src/tests/Publishing.Core.Tests/ConsoleUiNotifierTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Services;
+using System;
+using System.IO;
+
+namespace Publishing.Core.Tests
+{
+    [TestClass]
+    public class ConsoleUiNotifierTests
+    {
+        [TestMethod]
+        public void NotifyMethods_WritePrefixes()
+        {
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            var notifier = new ConsoleUiNotifier();
+
+            notifier.NotifyInfo("i");
+            notifier.NotifyWarning("w");
+            notifier.NotifyError("e");
+
+            var expected = string.Join(Environment.NewLine, new[] {
+                "INFO: i",
+                "WARN: w",
+                "ERROR: e",
+                ""
+            });
+            Assert.AreEqual(expected, writer.ToString());
+        }
+
+        [TestMethod]
+        public void NotifyError_WritesDetails()
+        {
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            var notifier = new ConsoleUiNotifier();
+            var details = new string('a', 100);
+
+            notifier.NotifyError("boom", details);
+
+            var output = writer.ToString();
+            StringAssert.Contains(output, "ERROR: boom");
+            StringAssert.Contains(output, details);
+        }
+
+        [TestMethod]
+        public void Colors_ResetAfterWrite()
+        {
+            var original = Console.ForegroundColor;
+            var notifier = new ConsoleUiNotifier();
+            notifier.NotifyWarning("msg");
+            Assert.AreEqual(original, Console.ForegroundColor);
+        }
+    }
+}

--- a/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
@@ -83,6 +83,13 @@ namespace Publishing.Core.Tests
             public void PublishOrderUpdated(OrderDto order) => OrderUpdated?.Invoke(order);
         }
 
+        private class StubNotifier : IUiNotifier
+        {
+            public void NotifyInfo(string message) { }
+            public void NotifyWarning(string message) { }
+            public void NotifyError(string message, string? details = null) { }
+        }
+
         [TestMethod]
         public async Task Handle_ValidCommand_ReturnsOrder()
         {
@@ -93,7 +100,8 @@ namespace Publishing.Core.Tests
                 new CreateOrderCommandValidator(),
                 new StubDateTimeProvider(),
                 new StubUnitOfWork(),
-                new StubOrderEventsPublisher());
+                new StubOrderEventsPublisher(),
+                new StubNotifier());
             var cmd = new CreateOrderCommand("book","Intro",10,3,"P1","PR");
 
             var result = await handler.Handle(cmd, CancellationToken.None);

--- a/src/tests/Publishing.Core.Tests/HostSilentNotifierTests.cs
+++ b/src/tests/Publishing.Core.Tests/HostSilentNotifierTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Services;
+
+namespace Publishing.Core.Tests;
+
+[TestClass]
+public class HostSilentNotifierTests
+{
+    [TestMethod]
+    public void WebHost_UsesSilentNotifierWhenDisabled()
+    {
+        Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", "true");
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(s => s.AddUiNotifier())
+            .Build();
+        var notifier = host.Services.GetService(typeof(IUiNotifier));
+        Assert.IsInstanceOfType(notifier, typeof(SilentUiNotifier));
+        Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", null);
+    }
+}

--- a/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Resources;
+
+namespace Publishing.Core.Tests;
+
+[TestClass]
+public class NotificationsResourcesTests
+{
+    [TestMethod]
+    public void LocalizedResources_HaveAllKeys()
+    {
+        var baseRes = new ResourceManager("Publishing.Services.Resources.Notifications", typeof(Publishing.Services.SilentUiNotifier).Assembly);
+        foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
+        {
+            var key = ((System.Collections.DictionaryEntry)entry).Key.ToString();
+            AssertKey("uk-UA", key, baseRes);
+            AssertKey("en-US", key, baseRes);
+        }
+    }
+
+    private static void AssertKey(string culture, string key, ResourceManager manager)
+    {
+        string? translated = manager.GetString(key, new System.Globalization.CultureInfo(culture));
+        Assert.IsFalse(string.IsNullOrEmpty(translated), $"Missing translation for {key} in {culture}");
+    }
+}

--- a/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
+
+namespace Publishing.Core.Tests
+{
+    [TestClass]
+    public class ServiceCollectionExtensionsTests
+    {
+        [TestMethod]
+        public void AddUiNotifier_RespectsEnvironmentFlag()
+        {
+            var services = new ServiceCollection();
+            Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", "true");
+            services.AddUiNotifier();
+            var provider = services.BuildServiceProvider();
+            var notifier = provider.GetRequiredService<IUiNotifier>();
+            Assert.IsInstanceOfType(notifier, typeof(SilentUiNotifier));
+            Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", null);
+        }
+
+        [TestMethod]
+        public void AddUiNotifier_ReturnsPlatformSpecificImplementation()
+        {
+            var services = new ServiceCollection();
+            services.AddUiNotifier();
+            var provider = services.BuildServiceProvider();
+            var notifier = provider.GetRequiredService<IUiNotifier>();
+            if (OperatingSystem.IsWindows())
+                Assert.IsInstanceOfType(notifier, typeof(WinFormsUiNotifier));
+            else
+                Assert.IsInstanceOfType(notifier, typeof(ConsoleUiNotifier));
+        }
+    }
+}

--- a/src/tests/Publishing.Core.Tests/SilentUiNotifierTests.cs
+++ b/src/tests/Publishing.Core.Tests/SilentUiNotifierTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Services;
+
+namespace Publishing.Core.Tests;
+
+[TestClass]
+public class SilentUiNotifierTests
+{
+    [TestMethod]
+    public void Methods_DoNotThrow()
+    {
+        var notifier = new SilentUiNotifier();
+        notifier.NotifyInfo("i");
+        notifier.NotifyWarning("w");
+        notifier.NotifyError("e", "d");
+    }
+}

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Resources;
+
+namespace Publishing.Core.Tests;
+
+[TestClass]
+public class UIResourcesTests
+{
+    [TestMethod]
+    public void AllKeys_HaveUkrainianTranslation()
+    {
+        var baseRes = new ResourceManager("Publishing.UI.Resources.Resources", typeof(Publishing.Services.SilentUiNotifier).Assembly);
+        foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
+        {
+            var key = ((System.Collections.DictionaryEntry)entry).Key.ToString();
+            string? translated = baseRes.GetString(key, new System.Globalization.CultureInfo("uk"));
+            Assert.IsFalse(string.IsNullOrEmpty(translated), $"Missing translation for {key}");
+        }
+    }
+}

--- a/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
+++ b/src/tests/Publishing.Integration.Tests/CrudFlowTests.cs
@@ -53,6 +53,7 @@ namespace Publishing.Integration.Tests
                 .Build();
             var services = new ServiceCollection();
             services.AddSingleton<IConfiguration>(config);
+            services.AddUiNotifier();
             services.AddTransient<ILogger, LoggerService>();
             services.AddTransient<IDbConnectionFactory, SqliteDbConnectionFactory>();
             services.AddTransient<IDbContext, DapperDbContext>();

--- a/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/DataBaseIntegrationTests.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
 using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
 using System.IO;
@@ -45,6 +46,7 @@ namespace Publishing.Integration.Tests
                 .Build();
             var services = new ServiceCollection();
             services.AddSingleton<IConfiguration>(config);
+            services.AddUiNotifier();
             services.AddTransient<ILogger, LoggerService>();
             services.AddTransient<IDbConnectionFactory, SqliteDbConnectionFactory>();
             services.AddTransient<IDbContext, DapperDbContext>();

--- a/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
+++ b/src/tests/Publishing.Integration.Tests/SqlQueryTests.cs
@@ -3,6 +3,7 @@ using Publishing.Infrastructure.DataAccess;
 using Publishing.Infrastructure;
 using Publishing.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Caching.Memory;
@@ -37,6 +38,7 @@ public class SqlQueryTests
 
         var services = new ServiceCollection();
         services.AddTransient<ILogger, LoggerService>();
+        services.AddUiNotifier();
         services.AddSingleton<IDbConnectionFactory>(sp =>
             new SqliteDbConnectionFactory(new TestConfiguration(_cs), sp.GetRequiredService<ILogger>()));
         services.AddTransient<IDbContext, DapperDbContext>();

--- a/src/tests/Publishing.Integration.Tests/StatisticTests.cs
+++ b/src/tests/Publishing.Integration.Tests/StatisticTests.cs
@@ -10,6 +10,7 @@ using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO;
+using Publishing.Services;
 
 namespace Publishing.Integration.Tests
 {
@@ -44,6 +45,7 @@ namespace Publishing.Integration.Tests
                 .Build();
             var services = new ServiceCollection();
             services.AddSingleton<IConfiguration>(config);
+            services.AddUiNotifier();
             services.AddTransient<ILogger, LoggerService>();
             services.AddTransient<IDbConnectionFactory, SqliteDbConnectionFactory>();
             services.AddTransient<IDbContext, DapperDbContext>();

--- a/src/tests/Publishing.UI.Tests/BalloonTests.cs
+++ b/src/tests/Publishing.UI.Tests/BalloonTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Remote;
+using System;
+using System.Linq;
+
+namespace Publishing.UI.Tests;
+
+[TestClass]
+public class BalloonTests
+{
+    private WindowsDriver<WindowsElement>? _session;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var opts = new DesiredCapabilities();
+        opts.SetCapability("app", "Publishing.UI.exe");
+        _session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _session?.Quit();
+    }
+
+    [TestMethod]
+    public void ShowsSuccessBalloon()
+    {
+        _session!.FindElementByAccessibilityId("emailTextBox").SendKeys("demo@demo.com");
+        _session.FindElementByAccessibilityId("passwordTextBox").SendKeys("pass");
+        _session.FindElementByAccessibilityId("loginButton").Click();
+        _session.FindElementByAccessibilityId("додатиToolStripMenuItem").Click();
+        _session.FindElementByAccessibilityId("nameProductTextBox").SendKeys("book");
+        _session.FindElementByAccessibilityId("pageNumTextBox").SendKeys("10");
+        _session.FindElementByAccessibilityId("tirageTextBox").SendKeys("1");
+        _session.FindElementByAccessibilityId("orderButton").Click();
+        System.Threading.Thread.Sleep(1000);
+        var screenshot = _session.GetScreenshot();
+        screenshot.SaveAsFile("TestResults/screenshots/success.png");
+        Assert.IsNotNull(screenshot);
+    }
+
+    [TestMethod]
+    public void ShowsWarningOnInvalidInput()
+    {
+        _session!.FindElementByAccessibilityId("pageNumTextBox").SendKeys("abc");
+        _session.FindElementByAccessibilityId("calculateButton").Click();
+        System.Threading.Thread.Sleep(1000);
+        var screenshot = _session.GetScreenshot();
+        screenshot.SaveAsFile("TestResults/screenshots/warn.png");
+        Assert.IsNotNull(screenshot);
+    }
+}

--- a/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
+++ b/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="WinAppDriver" Version="1.4.2" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Publishing.UI/Publishing.UI.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Publishing.UI.Tests/WinFormsUiNotifierTests.cs
+++ b/src/tests/Publishing.UI.Tests/WinFormsUiNotifierTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Publishing.Services;
+
+namespace Publishing.UI.Tests
+{
+    [TestClass]
+    public class WinFormsUiNotifierTests
+    {
+        [TestMethod]
+        public void NotifyInfo_SetsBalloonProperties()
+        {
+            using var notifier = new WinFormsUiNotifier();
+            notifier.NotifyInfo("hello");
+
+            var field = typeof(WinFormsUiNotifier).GetField("_notifyIcon", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            var icon = (System.Windows.Forms.NotifyIcon)field!.GetValue(notifier)!;
+            Assert.AreEqual("Publishing", icon.BalloonTipTitle);
+            Assert.AreEqual("hello", icon.BalloonTipText);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DI snippet and stub setup in README
- enable ANSI coloring in `ConsoleUiNotifier`
- allow disabling notifications via environment variable
- move navigation helpers into WinForms project
- wire `IUiNotifier` into forms and handlers
- add Windows job to CI and analyzer for missing notifier
- document UI testing approach
- integrate analyzer via Directory.Build.props and add Windows UI test placeholder
- replace notifier calls with error handler
- finish replacing MessageBox usage with notifier and remove `#if WINDOWS` preprocessor
- localize notifier messages and add resource checks
- remove ShowFriendlyError API and register notifier disposal
- refine analyzer logic and forbid MessageBox/`#if WINDOWS`
- replace outdated resource keys in WinForms forms
- refine CI and analyzer tests
- add docker variable to silence notifications

## Testing
- ❌ `dotnet format --no-restore --verify-no-changes` *(failed: `dotnet: command not found`)*
- ❌ `dotnet test --no-build` *(failed: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685886b2b2d08320a54fb54dceedb6a8