### PR TITLE
Fix project dependencies and move JWT interface

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -10,6 +10,7 @@ using Publishing.Services;
 using Publishing.Services.ErrorHandling;
 using Publishing.Services.Roles;
 using Publishing.Services.Jwt;
+using Publishing.Core.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Publishing.Core/Interfaces/IJwtFactory.cs
+++ b/src/Publishing.Core/Interfaces/IJwtFactory.cs
@@ -1,0 +1,9 @@
+using Publishing.Core.DTOs;
+
+namespace Publishing.Core.Interfaces
+{
+    public interface IJwtFactory
+    {
+        string GenerateToken(UserDto user);
+    }
+}

--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="FluentValidation" Version="11.9.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../Publishing.Services/Publishing.Services.csproj" />
+    <!-- Core depends only on abstractions defined here -->
   </ItemGroup>
 
 </Project>

--- a/src/Publishing.Core/Services/AuthService.cs
+++ b/src/Publishing.Core/Services/AuthService.cs
@@ -2,7 +2,6 @@ using System;
 using BCrypt.Net;
 using Publishing.Core.DTOs;
 using Publishing.Core.Interfaces;
-using Publishing.Services;
 using System.Threading.Tasks;
 
 namespace Publishing.Core.Services

--- a/src/Publishing.Services/Jwt/IJwtFactory.cs
+++ b/src/Publishing.Services/Jwt/IJwtFactory.cs
@@ -1,8 +1,0 @@
-namespace Publishing.Services;
-
-using Publishing.Core.DTOs;
-
-public interface IJwtFactory
-{
-    string GenerateToken(UserDto user);
-}

--- a/src/Publishing.Services/Jwt/JwtFactory.cs
+++ b/src/Publishing.Services/Jwt/JwtFactory.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using Publishing.Core.DTOs;
+using Publishing.Core.Interfaces;
 
 namespace Publishing.Services;
 

--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -4,10 +4,14 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms Condition="'$(TargetFramework)'=='net6.0-windows'">true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
+  <ItemGroup>
+    <!-- Dependency injection extensions used across all targets -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <Compile Include="UiNotifications/WinFormsUiNotifier.cs" />
-    <Compile Include="ServiceCollectionExtensions.Windows.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
+    <!-- WinForms-specific implementations are included by default -->
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.31.0" />
@@ -17,5 +21,8 @@
   <ItemGroup Condition="'$(TargetFramework)'!='net6.0-windows'">
     <Compile Remove="UiNotifications/WinFormsUiNotifier.cs" />
     <Compile Remove="ServiceCollectionExtensions.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Publishing.Core/Publishing.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- move `IJwtFactory` interface to `Publishing.Core`
- update `JwtFactory` and `AuthService` to use new interface location
- update API gateway to include `Publishing.Core.Interfaces`
- add missing packages and project reference in `Publishing.Services`
- clean up cyclic dependency from `Publishing.Core`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593126d3f88320a79d10c9fb8af1c7