### PR TITLE
Fix analyzer path and build errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <ItemGroup>
-    <ProjectReference Include="src/Publishing.Analyzers/Publishing.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Publishing.Core/Publishing.Core.csproj
+++ b/src/Publishing.Core/Publishing.Core.csproj
@@ -12,11 +12,12 @@
     <Folder Include="Services/" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="FluentValidation" Version="11.9.0" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+      <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+      <PackageReference Include="FluentValidation" Version="11.9.0" />
+      <PackageReference Include="MediatR" Version="12.1.1" />
+    </ItemGroup>
   <ItemGroup>
     <!-- Core depends only on abstractions defined here -->
   </ItemGroup>

--- a/src/Publishing.Services/Events/OrderEventsPublisher.cs
+++ b/src/Publishing.Services/Events/OrderEventsPublisher.cs
@@ -1,5 +1,6 @@
 namespace Publishing.Services;
 
+using System;
 using Publishing.Core.DTOs;
 
 public class OrderEventsPublisher : IOrderEventsPublisher

--- a/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Text.Json;
 using RabbitMQ.Client;

--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
     <!-- WinForms-specific implementations are included by default -->
@@ -21,6 +22,9 @@
   <ItemGroup Condition="'$(TargetFramework)'!='net6.0-windows'">
     <Compile Remove="UiNotifications/WinFormsUiNotifier.cs" />
     <Compile Remove="ServiceCollectionExtensions.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
+    <Compile Remove="ServiceCollectionExtensions.NonWindows.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Publishing.Core/Publishing.Core.csproj" />


### PR DESCRIPTION
## Summary
- correct path to analyzer project via `$(MSBuildThisFileDirectory)`
- add MediatR to Publishing.Core
- fix missing `System` usings in event publishers
- add configuration package to Publishing.Services and conditionally exclude platform files

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685939403fd0832082eb5c8f9a45a8d1