### PR TITLE
Fix circular analyzer reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
-  <ItemGroup>
+  <!-- Attach analyzer project as an Analyzer to all projects except the analyzer itself -->
+  <ItemGroup Condition="'$(MSBuildProjectFullPath)' != '$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />


### PR DESCRIPTION
## Summary
- conditionally exclude `Publishing.Analyzers` from referencing itself

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593ae30b8c8320a90798bf2595d8b3