### PR TITLE
Fix analyzer self-reference condition

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <!-- Attach analyzer project as an Analyzer to all projects except the analyzer itself -->
-  <ItemGroup Condition="'$(MSBuildProjectFullPath)' != '$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Publishing.Analyzers'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />


### PR DESCRIPTION
## Summary
- ensure the analyzer project doesn't reference itself across OS

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68593c5bd2d083208df91b55ab5aca6b