### PR TITLE
Fix analyzer build with stable packages

### DIFF
--- a/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
+++ b/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.2.0-beta1.23556.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />


### PR DESCRIPTION
## Summary
- use stable Microsoft.CodeAnalysis testing package
- include `System.Linq` so ForbiddenApiAnalyzer builds

## Testing
- `dotnet nuget locals all --clear` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594d0265588320a6fde2695e24da6d