### PR TITLE
Fix build by removing missing Http.Json package

### DIFF
--- a/src/Publishing.Services/ErrorHandling/ExceptionHandlingMiddleware.cs
+++ b/src/Publishing.Services/ErrorHandling/ExceptionHandlingMiddleware.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Json;
 
 namespace Publishing.Services;
 
@@ -29,7 +29,8 @@ public class ExceptionHandlingMiddleware
             {
                 context.Response.StatusCode = 500;
                 context.Response.ContentType = "application/json";
-                await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+                await context.Response.WriteAsync(
+                    JsonSerializer.Serialize(new { error = ex.Message }));
             }
         }
     }

--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Json" Version="6.0.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">


### PR DESCRIPTION
## Summary
- remove unused `Microsoft.AspNetCore.Http.Json` package reference
- replace `WriteAsJsonAsync` with explicit `JsonSerializer` usage

## Testing
- N/A (dotnet unavailable)


------
https://chatgpt.com/codex/tasks/task_e_6859601631d4832092f7fb5c4ac989f0