### PR TITLE
Fix handler interfaces and notifier namespace

### DIFF
--- a/src/Publishing.Application/Handlers/UpdateOrganizationHandler.cs
+++ b/src/Publishing.Application/Handlers/UpdateOrganizationHandler.cs
@@ -5,11 +5,12 @@ using MediatR;
 using FluentValidation;
 using Publishing.Core.Commands;
 using Publishing.Core.Interfaces;
+using Publishing.Services;
 using System.Resources;
 
 namespace Publishing.AppLayer.Handlers;
 
-public class UpdateOrganizationHandler : IRequestHandler<UpdateOrganizationCommand>
+public class UpdateOrganizationHandler : IRequestHandler<UpdateOrganizationCommand, Unit>
 {
     private readonly IOrganizationRepository _repo;
     private readonly IValidator<UpdateOrganizationCommand> _validator;

--- a/src/Publishing.Application/Handlers/UpdateProfileHandler.cs
+++ b/src/Publishing.Application/Handlers/UpdateProfileHandler.cs
@@ -5,11 +5,12 @@ using MediatR;
 using FluentValidation;
 using Publishing.Core.Commands;
 using Publishing.Core.Interfaces;
+using Publishing.Services;
 using System.Resources;
 
 namespace Publishing.AppLayer.Handlers;
 
-public class UpdateProfileHandler : IRequestHandler<UpdateProfileCommand>
+public class UpdateProfileHandler : IRequestHandler<UpdateProfileCommand, Unit>
 {
     private readonly IProfileRepository _repo;
     private readonly IValidator<UpdateProfileCommand> _validator;


### PR DESCRIPTION
## Summary
- fix `UpdateProfileHandler` and `UpdateOrganizationHandler` implementation
- add notifier namespace for handlers

## Testing
- ❌ `dotnet test` *(failed: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685960d2626c8320a9564e2044c8027e