### PR TITLE
Fix package references for tests

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -10,6 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <!-- Match the compiler shipped with .NET 6 SDK -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -7,8 +7,9 @@
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.2.0" />
+    <!-- Use analyzer testing library compatible with .NET 6 -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />

--- a/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
+++ b/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="Microsoft.Windows.AppDriver" Version="1.3.0" />
+    <!-- Use Appium library directly for WinAppDriver UI tests -->
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- fix compiler package version for Publishing.Analyzers
- use compatible analyzer testing package
- replace missing Windows AppDriver package with Appium.WebDriver

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685963c727588320aaa106e5ef93ffdf