### PR TITLE
Fix analyzer dependencies and Selenium version

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Version>1.0.0</Version>
+    <!-- Ensure analyzer dependencies are copied so consumer projects can load them -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Publishing Team</Authors>
     <PackageProjectUrl>https://github.com/example/publishing</PackageProjectUrl>
@@ -12,5 +14,7 @@
   <ItemGroup>
     <!-- Match the compiler shipped with .NET 6 SDK -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <!-- Explicitly reference Immutable collection library used by analyzers -->
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
+++ b/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
@@ -12,7 +12,8 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <!-- Use Appium library directly for WinAppDriver UI tests -->
     <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <!-- Align Selenium version with Appium dependency to avoid downgrade warnings -->
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.UI/Publishing.UI.csproj" />


### PR DESCRIPTION
## Summary
- ensure analyzer dependencies are copied with `CopyLocalLockFileAssemblies`
- explicitly reference `System.Collections.Immutable`
- align `Selenium.WebDriver` version with `Appium.WebDriver`

## Testing
- `dotnet test Publishing.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685965cf845483209371c2a633457ec3