### PR TITLE
Fix analyzer load failures

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Version>1.0.0</Version>
-    <!-- Ensure analyzer dependencies are copied so consumer projects can load them -->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Publishing Team</Authors>
     <PackageProjectUrl>https://github.com/example/publishing</PackageProjectUrl>
@@ -14,7 +12,5 @@
   <ItemGroup>
     <!-- Match the compiler shipped with .NET 6 SDK -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
-    <!-- Explicitly reference Immutable collection library used by analyzers -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- target analyzers for `netstandard2.0` and drop copy local/dependency references so Roslyn can load them without `System.Collections.Immutable`

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859669a072c8320956be5c14276a384