### PR TITLE
Fix analyzer build

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -8,6 +8,8 @@
     <PackageProjectUrl>https://github.com/example/publishing</PackageProjectUrl>
     <Description>Analyzers enforcing UI notifier usage and API restrictions.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- Enable newer C# language features used by the analyzers -->
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Match the compiler shipped with .NET 6 SDK -->


### PR DESCRIPTION
## Summary
- enable C#10 compiler features for analyzer project

## Testing
- `dotnet build --no-restore src/Publishing.Analyzers/Publishing.Analyzers.csproj -c Debug` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859676dc7f4832093526378f4319c12