### PR TITLE
Fix analyzer dependency

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -14,5 +14,7 @@
   <ItemGroup>
     <!-- Match the compiler shipped with .NET 6 SDK -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <!-- Explicitly reference System.Collections.Immutable to satisfy analyzer dependencies -->
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <!-- Use analyzer testing library compatible with .NET 6 -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <!-- Provide System.Collections.Immutable to satisfy analyzer dependencies when running tests -->
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
- add missing System.Collections.Immutable package to analyzers
- include the same dependency when running analyzer tests

## Testing
- `dotnet test Publishing.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685968125d6883209a13bcb554e3ff4c