### PR TITLE
Fix JWT key length

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,7 @@ RABBIT_CONN=amqp://guest:guest@rabbit/
 
 JWT__Issuer=example.com
 JWT__Audience=example.com
-JWT__SigningKey=YOUR_SECRET_KEY_HERE
+# Signing key used to sign and validate JWTs.
+# Must be at least 16 characters long for HS256.
+JWT__SigningKey=MySuperSecretKey12345
 # use the same values when generating JWT tokens

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker-compose up --build
 
 The API gateway project under `src/ApiGateway` routes requests to the services. Swagger is enabled for each service at `/swagger` and health checks are exposed at `/health`.
 Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `SA_PASSWORD`, `ACCEPT_EULA`, `DB_CONN`, `REDIS_CONN`, `RABBIT_CONN`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
-The issuer, audience and signing key must match the values used to sign JWT tokens consumed by the services.
+The signing key must be at least 16 characters long when using the default HS256 algorithm. The issuer, audience and key must match the values used to sign JWT tokens consumed by the services.
 Set `ASPNETCORE_ENVIRONMENT=Development` in the compose file (or `.env`) to enable Swagger inside the containers. Change or remove this variable to run the services in production.
 Database migrations now apply **asynchronously** during startup and each service reports readiness via `/health`.
 All API routes require an `Authorization: Bearer <token>` header containing a JWT signed with the configured key.

--- a/src/Publishing.Services/Jwt/JwtFactory.cs
+++ b/src/Publishing.Services/Jwt/JwtFactory.cs
@@ -22,7 +22,7 @@ public class JwtFactory : IJwtFactory
     {
         var issuer = _configuration["JWT:Issuer"] ?? "example.com";
         var audience = _configuration["JWT:Audience"] ?? "example.com";
-        var signingKey = _configuration["JWT:SigningKey"] ?? "SecretKey123";
+        var signingKey = _configuration["JWT:SigningKey"] ?? "MySuperSecretKey12345";
 
         var claims = new[]
         {

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -15,7 +15,7 @@ public class OrderContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -15,7 +15,7 @@ public class OrganizationContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -15,7 +15,7 @@ public class ProfileContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("SecretKey123"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",


### PR DESCRIPTION
## Summary
- use a longer default JWT signing key in `JwtFactory`
- update contract tests to match the new key
- document required key length in README
- provide an example signing key in `.env.example`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596b46dde48320b060e1fda5f33535