### PR TITLE
Update analyzers to Roslyn 4.3

### DIFF
--- a/src/Publishing.Analyzers/Publishing.Analyzers.csproj
+++ b/src/Publishing.Analyzers/Publishing.Analyzers.csproj
@@ -15,9 +15,13 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Match the compiler shipped with .NET 6 SDK -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
-    <!-- Explicitly reference System.Collections.Immutable so the compiler can load the analyzer -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <!-- Roslyn 4.3.1 підтягує Immutable 5.0.0 -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"
+                      Version="4.3.1"
+                      PrivateAssets="all" />
+    <!-- Явно фіксуємо потрібну збірку, щоб NuGet поклав її у вихід -->
+    <PackageReference Include="System.Collections.Immutable"
+                      Version="5.0.0"
+                      PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
     <!-- Use analyzer testing library compatible with .NET 6 -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <!-- Provide System.Collections.Immutable to satisfy analyzer dependencies when running tests -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <!-- Provide System.Collections.Immutable so analyzers can load -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.22" />

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <!-- Provide System.Collections.Immutable so analyzers can load -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.22" />

--- a/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
+++ b/src/tests/Publishing.UI.Tests/Publishing.UI.Tests.csproj
@@ -15,7 +15,7 @@
     <!-- Align Selenium version with Appium dependency to avoid downgrade warnings -->
     <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
     <!-- Provide System.Collections.Immutable so analyzers can load -->
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.UI/Publishing.UI.csproj" />


### PR DESCRIPTION
## Summary
- lower analyzer dependencies to Roslyn 4.3.1
- force System.Collections.Immutable 5.0.0 throughout tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596fd5ff0083209870a4a73300cec3