### PR TITLE
Fix compile issues in test suite

### DIFF
--- a/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
@@ -7,6 +7,8 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Services;
+using AutoMapper;
+using Publishing.AppLayer.Mapping;
 using Publishing.Core.DTOs;
 using System;
 using System.Threading;
@@ -99,9 +101,11 @@ namespace Publishing.Core.Tests
         {
             var repo = new StubOrderRepository();
             var printery = new StubPrinteryRepository();
+            var mapper = new MapperConfiguration(cfg => cfg.AddProfile<OrderProfile>()).CreateMapper();
             var handler = new CreateOrderHandler(repo, printery,
                 new PriceCalculator(new StandardDiscountPolicy()),
                 new CreateOrderCommandValidator(),
+                mapper,
                 new StubDateTimeProvider(),
                 new StubUnitOfWork(),
                 new StubOrderEventsPublisher(),

--- a/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
@@ -12,7 +12,7 @@ public class NotificationsResourcesTests
         var baseRes = new ResourceManager("Publishing.Services.Resources.Notifications", typeof(Publishing.Services.SilentUiNotifier).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
-            var key = ((System.Collections.DictionaryEntry)entry).Key.ToString();
+            var key = ((System.Collections.DictionaryEntry)entry).Key!.ToString();
             AssertKey("uk-UA", key, baseRes);
             AssertKey("en-US", key, baseRes);
         }

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.22" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />

--- a/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -27,10 +27,11 @@ namespace Publishing.Core.Tests
             services.AddUiNotifier();
             var provider = services.BuildServiceProvider();
             var notifier = provider.GetRequiredService<IUiNotifier>();
+            var typeName = notifier.GetType().Name;
             if (OperatingSystem.IsWindows())
-                Assert.IsInstanceOfType(notifier, typeof(WinFormsUiNotifier));
+                Assert.AreEqual("WinFormsUiNotifier", typeName);
             else
-                Assert.IsInstanceOfType(notifier, typeof(ConsoleUiNotifier));
+                Assert.AreEqual("ConsoleUiNotifier", typeName);
         }
     }
 }

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -12,7 +12,7 @@ public class UIResourcesTests
         var baseRes = new ResourceManager("Publishing.UI.Resources.Resources", typeof(Publishing.Services.SilentUiNotifier).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
-            var key = ((System.Collections.DictionaryEntry)entry).Key.ToString();
+            var key = ((System.Collections.DictionaryEntry)entry).Key!.ToString();
             string? translated = baseRes.GetString(key, new System.Globalization.CultureInfo("uk"));
             Assert.IsFalse(string.IsNullOrEmpty(translated), $"Missing translation for {key}");
         }

--- a/src/tests/Publishing.UI.Tests/BalloonTests.cs
+++ b/src/tests/Publishing.UI.Tests/BalloonTests.cs
@@ -11,14 +11,14 @@ namespace Publishing.UI.Tests;
 [TestCategory("UI")]
 public class BalloonTests
 {
-    private WindowsDriver<WindowsElement>? _session;
+    private OpenQA.Selenium.Appium.Windows.WindowsDriver<OpenQA.Selenium.Appium.Windows.WindowsElement>? _session;
 
     [TestInitialize]
     public void Setup()
     {
         var opts = new AppiumOptions();
         opts.AddAdditionalAppiumOption(MobileCapabilityType.App, "Publishing.UI.exe");
-        _session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
+        _session = new OpenQA.Selenium.Appium.Windows.WindowsDriver<OpenQA.Selenium.Appium.Windows.WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
     }
 
     [TestCleanup]


### PR DESCRIPTION
## Summary
- fix platform notifier assertion without referencing Windows-specific classes
- ensure resource tests treat keys as non-null
- provide AutoMapper instance for `CreateOrderHandler` tests
- add hosting package for Host tests
- fix WinAppDriver generic type usage

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68597f4ba8dc8320a402a909f938d7a2