### PR TITLE
Fix compilation issues in unit tests

### DIFF
--- a/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/NotificationsResourcesTests.cs
@@ -12,7 +12,14 @@ public class NotificationsResourcesTests
         var baseRes = new ResourceManager("Publishing.Services.Resources.Notifications", typeof(Publishing.Services.SilentUiNotifier).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
-            var key = ((System.Collections.DictionaryEntry)entry).Key!.ToString();
+            // DictionaryEntry.Key is of type object and might technically be null
+            // but resource keys are expected to be strings. Cast defensively and
+            // skip entries without a valid key to satisfy nullable analysis.
+            if (((System.Collections.DictionaryEntry)entry).Key is not string key)
+            {
+                continue;
+            }
+
             AssertKey("uk-UA", key, baseRes);
             AssertKey("en-US", key, baseRes);
         }

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -12,7 +12,12 @@ public class UIResourcesTests
         var baseRes = new ResourceManager("Publishing.UI.Resources.Resources", typeof(Publishing.Services.SilentUiNotifier).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
-            var key = ((System.Collections.DictionaryEntry)entry).Key!.ToString();
+            // Skip entries without a valid string key to avoid nullable warnings.
+            if (((System.Collections.DictionaryEntry)entry).Key is not string key)
+            {
+                continue;
+            }
+
             string? translated = baseRes.GetString(key, new System.Globalization.CultureInfo("uk"));
             Assert.IsFalse(string.IsNullOrEmpty(translated), $"Missing translation for {key}");
         }

--- a/src/tests/Publishing.UI.Tests/BalloonTests.cs
+++ b/src/tests/Publishing.UI.Tests/BalloonTests.cs
@@ -11,14 +11,16 @@ namespace Publishing.UI.Tests;
 [TestCategory("UI")]
 public class BalloonTests
 {
-    private OpenQA.Selenium.Appium.Windows.WindowsDriver<OpenQA.Selenium.Appium.Windows.WindowsElement>? _session;
+    // In Appium.WebDriver versions referenced by this project the WindowsDriver
+    // type isn't generic, so use the non-generic form for the session instance.
+    private OpenQA.Selenium.Appium.Windows.WindowsDriver? _session;
 
     [TestInitialize]
     public void Setup()
     {
         var opts = new AppiumOptions();
         opts.AddAdditionalAppiumOption(MobileCapabilityType.App, "Publishing.UI.exe");
-        _session = new OpenQA.Selenium.Appium.Windows.WindowsDriver<OpenQA.Selenium.Appium.Windows.WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
+        _session = new OpenQA.Selenium.Appium.Windows.WindowsDriver(new Uri("http://127.0.0.1:4723"), opts);
     }
 
     [TestCleanup]


### PR DESCRIPTION
## Summary
- switch WinAppDriver tests to use non-generic `WindowsDriver`
- add nullable-safe checks when enumerating resource keys

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685980ed18a883209f3f4c9f30f501e5