### PR TITLE
Fix compile error in Appium UI tests

### DIFF
--- a/src/tests/Publishing.UI.Tests/BalloonTests.cs
+++ b/src/tests/Publishing.UI.Tests/BalloonTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium;
+using AppiumBy = OpenQA.Selenium.Appium.AppiumBy;
 using System;
 
 


### PR DESCRIPTION
## Summary
- alias `AppiumBy` to its full namespace so UI tests compile

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685981df68f08320a19d5f547181f251