### PR TITLE
Fix test project references

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
     <!-- Use analyzer testing library compatible with .NET 6 -->
@@ -13,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Analyzers/Publishing.Analyzers.csproj" />

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -23,5 +23,6 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Application/Publishing.Application.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
+    <ProjectReference Include="../../Publishing.UI/Publishing.UI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- target Windows for analyzer tests so WinForms APIs compile
- add AspNetCore framework reference for analyzer tests
- reference Publishing.UI from core tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859854792188320927039f17a074c11