### PR TITLE
Fix build for tests on non-Windows

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.ReferenceAssemblies;
 using Publishing.Analyzers;
 
 namespace Publishing.Analyzers.Tests;

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <!-- Use analyzer testing library compatible with .NET 6 -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />

--- a/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
+++ b/src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net6.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseWindowsForms Condition=" '$(TargetFramework)' == 'net6.0-windows'">true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
@@ -23,6 +24,8 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Application/Publishing.Application.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
     <ProjectReference Include="../../Publishing.UI/Publishing.UI.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -3,6 +3,7 @@ using System.Resources;
 
 namespace Publishing.Core.Tests;
 
+#if WINDOWS
 [TestClass]
 public class UIResourcesTests
 {
@@ -25,3 +26,4 @@ public class UIResourcesTests
         }
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- add missing ReferenceAssemblies namespace for analyzer tests
- update analyzer test utilities package
- allow `Publishing.Core.Tests` to build both net6.0 and net6.0-windows and only reference UI project on Windows
- compile UI resources test only on Windows

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859862b5bcc83209ecab762b2719766