### PR TITLE
Fix test references for offline builds

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -10,7 +10,8 @@
   <ItemGroup>
     <!-- Use analyzer testing library compatible with .NET 6 -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.2.0" />
+    <!-- Version 1.2.0 is not available in the offline feed; use the latest 1.1.x -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -11,8 +11,8 @@ public class UIResourcesTests
     public void AllKeys_HaveUkrainianTranslation()
     {
         var baseRes = new ResourceManager(
-            "Publishing.UI.Resources.Resources",
-            typeof(Publishing.UI.Program).Assembly);
+            "Publishing.Resources.Resources",
+            typeof(Publishing.Program).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
             // Skip entries without a valid string key to avoid nullable warnings.


### PR DESCRIPTION
## Summary
- switch analyzer test package to version 1.1.2 so restoring works without internet
- correct resource manager namespace in UI resources test

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685987365fe48320ace8bfb21c3bf843