### PR TITLE
Fix Analyzer and resource test build errors

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.ReferenceAssemblies;
+using static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies;
 using Publishing.Analyzers;
 
 namespace Publishing.Analyzers.Tests;

--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Resources;
+using Publishing;
 
 namespace Publishing.Core.Tests;
 
@@ -12,7 +13,7 @@ public class UIResourcesTests
     {
         var baseRes = new ResourceManager(
             "Publishing.Resources.Resources",
-            typeof(Publishing.Program).Assembly);
+            typeof(loginForm).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
             // Skip entries without a valid string key to avoid nullable warnings.


### PR DESCRIPTION
## Summary
- fix using directive for ReferenceAssemblies
- reference a public type when loading UI resource assembly

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68598807b2688320a6c3508b1d585773