### PR TITLE
Fix analyzer and notifier tests

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -23,9 +23,17 @@ public class AnalyzerTests
         };
 #pragma warning restore CS0618
 
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var compilationOptions = solution.GetProject(projectId)!.CompilationOptions!
+                .WithOutputKind(OutputKind.ConsoleApplication);
+            return solution.WithProjectCompilationOptions(projectId, compilationOptions);
+        });
+
         test.TestState.AdditionalReferences.Add(typeof(Microsoft.Extensions.DependencyInjection.ServiceCollection).Assembly);
         test.TestState.AdditionalReferences.Add(typeof(Microsoft.AspNetCore.Builder.WebApplication).Assembly);
         test.TestState.AdditionalReferences.Add(typeof(System.Windows.Forms.Form).Assembly);
+        test.TestState.AdditionalReferences.Add(typeof(Publishing.Services.IUiNotifier).Assembly);
         await test.RunAsync();
     }
 

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -19,5 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Publishing.Analyzers/Publishing.Analyzers.csproj" />
+    <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -28,10 +28,11 @@ namespace Publishing.Core.Tests
             var provider = services.BuildServiceProvider();
             var notifier = provider.GetRequiredService<IUiNotifier>();
             var typeName = notifier.GetType().Name;
-            if (OperatingSystem.IsWindows())
-                Assert.AreEqual("WinFormsUiNotifier", typeName);
-            else
-                Assert.AreEqual("ConsoleUiNotifier", typeName);
+#if WINDOWS
+            Assert.AreEqual("WinFormsUiNotifier", typeName);
+#else
+            Assert.AreEqual("ConsoleUiNotifier", typeName);
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- reference Publishing.Services in analyzer tests
- adjust analyzer test harness to compile as an executable and include service assembly
- use compile-time check in notifier platform test

## Testing
- `dotnet test --no-build -c Release src/Publishing.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598a319a8883208423e17cca7e44e1