### PR TITLE
Fix missing OutputKind reference

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies;
 using Publishing.Analyzers;


### PR DESCRIPTION
## Summary
- add missing `Microsoft.CodeAnalysis` using directive in analyzer test

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68598ae5dce483208289fe4244e3e5c5