### PR TITLE
Fix missing parenthesis in ForbiddenApiAnalyzer

### DIFF
--- a/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
+++ b/src/Publishing.Analyzers/ForbiddenApiAnalyzer.cs
@@ -55,7 +55,7 @@ public class ForbiddenApiAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeTree(SyntaxTreeAnalysisContext context)
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
-        foreach (var directive in root.DescendantTrivia().Where(t => t.IsKind(SyntaxKind.IfDirectiveTrivia))
+        foreach (var directive in root.DescendantTrivia().Where(t => t.IsKind(SyntaxKind.IfDirectiveTrivia)))
         {
             var ifDir = (IfDirectiveTriviaSyntax)directive.GetStructure();
             if (ifDir != null && ifDir.Condition.ToString().Contains("WINDOWS"))


### PR DESCRIPTION
## Summary
- fix compile error in `ForbiddenApiAnalyzer`

## Testing
- `dotnet format --no-restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598cf1b8788320a71a34bd20a2197c