### PR TITLE
Fix analyzer tests failing due to incorrect strings

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -41,21 +41,23 @@ public class AnalyzerTests
     [TestMethod]
     public async Task ConfigureServicesWithoutCall_ProducesWarning()
     {
-        var code = @"using Microsoft.Extensions.DependencyInjection;\nclass Startup{void ConfigureServices(IServiceCollection s){}}";
+        var code = @"using Microsoft.Extensions.DependencyInjection;
+class Startup{void ConfigureServices(IServiceCollection s){}}";
         await VerifyAsync<AddUiNotifierAnalyzer>(code);
     }
 
     [TestMethod]
     public async Task ConfigureServicesWithCall_NoWarning()
     {
-        var code = @"using Microsoft.Extensions.DependencyInjection;\nclass Startup{void ConfigureServices(IServiceCollection s){s.AddUiNotifier();}}";
+        var code = @"using Microsoft.Extensions.DependencyInjection;
+class Startup{void ConfigureServices(IServiceCollection s){s.AddUiNotifier();}}";
         await VerifyAsync<AddUiNotifierAnalyzer>(code);
     }
 
     [TestMethod]
     public async Task ProgramWithoutCall_ProducesDiagnostic()
     {
-        var code = "using Microsoft.Extensions.DependencyInjection;\nvar builder = WebApplication.CreateBuilder();";
+        var code = "using Microsoft.Extensions.DependencyInjection;\nusing Microsoft.AspNetCore.Builder;\nvar builder = WebApplication.CreateBuilder();";
         await VerifyAsync<AddUiNotifierAnalyzer>(code);
     }
 
@@ -70,6 +72,7 @@ public class AnalyzerTests
     public async Task BuilderServicesVariable_NoDiagnostic()
     {
         var code = @"using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
 var builder = WebApplication.CreateBuilder();
 var svcs = builder.Services;
 svcs.AddLogging();


### PR DESCRIPTION
## Summary
- fix analyzer test strings to use real newlines
- add missing `using Microsoft.AspNetCore.Builder` in analyzer tests

## Testing
- `dotnet test --no-build --verbosity minimal src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68598db306c0832084e59af14f493cb4