### PR TITLE
Fix analyzer test namespaces

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -54,6 +54,7 @@ class Program{static void Main(){}}";
     public async Task ConfigureServicesWithCall_NoWarning()
     {
         var code = @"using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
 class Startup{void ConfigureServices(IServiceCollection s){s.AddUiNotifier();}}
 class Program{static void Main(){}}";
         await VerifyAsync<AddUiNotifierAnalyzer>(code);
@@ -81,6 +82,7 @@ class Program{static void Main(){}}";
     public async Task BuilderServicesVariable_NoDiagnostic()
     {
         var code = @"using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
 using Microsoft.AspNetCore.Builder;
 var builder = WebApplication.CreateBuilder();
 var svcs = builder.Services;
@@ -110,6 +112,7 @@ class Program{static void Main(){}}";
     public async Task ExtensionMethodRegistration_NoDiagnostic()
     {
         var code = @"using Microsoft.Extensions.DependencyInjection;
+using Publishing.Services;
 static class Ext{public static void Reg(this IServiceCollection s){s.AddUiNotifier();}}
 class S{void ConfigureServices(IServiceCollection s){s.Reg();}}
 class Program{static void Main(){}}";


### PR DESCRIPTION
## Summary
- import `Publishing.Services` in analyzer test cases

## Testing
- `dotnet test --no-build --verbosity normal src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598ff930908320b09a2c98a5d06759