### PR TITLE
Add logging reference to analyzer tests

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/AnalyzerTests.cs
@@ -33,6 +33,7 @@ public class AnalyzerTests
 
         test.TestState.AdditionalReferences.Add(typeof(Microsoft.Extensions.DependencyInjection.ServiceCollection).Assembly);
         test.TestState.AdditionalReferences.Add(typeof(Microsoft.AspNetCore.Builder.WebApplication).Assembly);
+        test.TestState.AdditionalReferences.Add(typeof(Microsoft.Extensions.Logging.ILoggingBuilder).Assembly);
         test.TestState.AdditionalReferences.Add(typeof(System.Windows.Forms.Form).Assembly);
         test.TestState.AdditionalReferences.Add(typeof(Publishing.Services.IUiNotifier).Assembly);
         test.ExpectedDiagnostics.AddRange(expected);


### PR DESCRIPTION
## Summary
- update analyzer test setup with Microsoft.Extensions.Logging reference

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685990c5673483208bcd44949f30688a