### PR TITLE
Fix JWT signing key length

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,6 @@ RABBIT_CONN=amqp://guest:guest@rabbit/
 JWT__Issuer=example.com
 JWT__Audience=example.com
 # Signing key used to sign and validate JWTs.
-# Must be at least 16 characters long for HS256.
-JWT__SigningKey=MySuperSecretKey12345
+# Must be at least 32 characters long for HS256.
+JWT__SigningKey=MySuperSecretKey1234567890123456
 # use the same values when generating JWT tokens

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker-compose up --build
 
 The API gateway project under `src/ApiGateway` routes requests to the services. Swagger is enabled for each service at `/swagger` and health checks are exposed at `/health`.
 Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `SA_PASSWORD`, `ACCEPT_EULA`, `DB_CONN`, `REDIS_CONN`, `RABBIT_CONN`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
-The signing key must be at least 16 characters long when using the default HS256 algorithm. The issuer, audience and key must match the values used to sign JWT tokens consumed by the services.
+The signing key must be at least 32 characters long when using the default HS256 algorithm. The issuer, audience and key must match the values used to sign JWT tokens consumed by the services.
 Set `ASPNETCORE_ENVIRONMENT=Development` in the compose file (or `.env`) to enable Swagger inside the containers. Change or remove this variable to run the services in production.
 Database migrations now apply **asynchronously** during startup and each service reports readiness via `/health`.
 All API routes require an `Authorization: Bearer <token>` header containing a JWT signed with the configured key.

--- a/src/Publishing.Services/Jwt/JwtFactory.cs
+++ b/src/Publishing.Services/Jwt/JwtFactory.cs
@@ -22,7 +22,7 @@ public class JwtFactory : IJwtFactory
     {
         var issuer = _configuration["JWT:Issuer"] ?? "example.com";
         var audience = _configuration["JWT:Audience"] ?? "example.com";
-        var signingKey = _configuration["JWT:SigningKey"] ?? "MySuperSecretKey12345";
+        var signingKey = _configuration["JWT:SigningKey"] ?? "MySuperSecretKey1234567890123456";
 
         var claims = new[]
         {

--- a/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrderContracts.cs
@@ -15,7 +15,7 @@ public class OrderContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey1234567890123456"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",

--- a/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/OrganizationContracts.cs
@@ -15,7 +15,7 @@ public class OrganizationContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey1234567890123456"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",

--- a/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
+++ b/src/tests/Publishing.Contracts.Tests/ProfileContracts.cs
@@ -15,7 +15,7 @@ public class ProfileContracts
 {
     private static string CreateJwt()
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey12345"));
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("MySuperSecretKey1234567890123456"));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var token = new JwtSecurityToken(
             issuer: "example.com",


### PR DESCRIPTION
## Summary
- enforce 32-char default signing key for JWT tokens
- update environment example
- update README instructions
- adjust contract tests to use the longer key

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859925186008320b0cdc4c903e35f80