### PR TITLE
Enable UI notifications by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ var factory = new WebApplicationFactory<Program>()
     });
 ```
 
-Set `NOTIFICATIONS_DISABLED=true` to suppress all UI output. The Windows job in CI uses this flag except when running WinAppDriver tests.
+Set `NOTIFICATIONS_DISABLED=true` to suppress all UI output. Set it to `false` or remove the variable entirely when you want to see tray balloons or console text. The Windows job in CI uses this flag except when running WinAppDriver tests.
 
 ## Static Analysis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
-      - NOTIFICATIONS_DISABLED=true
+      - NOTIFICATIONS_DISABLED=false
     depends_on:
       db:
         condition: service_healthy
@@ -43,7 +43,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
-      - NOTIFICATIONS_DISABLED=true
+      - NOTIFICATIONS_DISABLED=false
     depends_on:
       db:
         condition: service_healthy
@@ -73,7 +73,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
-      - NOTIFICATIONS_DISABLED=true
+      - NOTIFICATIONS_DISABLED=false
     depends_on:
       db:
         condition: service_healthy
@@ -101,7 +101,7 @@ services:
       - JWT__Audience=${JWT__Audience}
       - JWT__SigningKey=${JWT__SigningKey}
       - ASPNETCORE_ENVIRONMENT=Development
-      - NOTIFICATIONS_DISABLED=true
+      - NOTIFICATIONS_DISABLED=false
     depends_on:
       orders:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- enable UI notifications in `docker-compose.yml`
- document how to enable or disable notifications in `README`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685993cbbc0c83208efdea60da2d1367