### PR TITLE
Handle whitespace in notifications flag

### DIFF
--- a/src/Publishing.Services/ServiceCollectionExtensions.cs
+++ b/src/Publishing.Services/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Publishing.Services
         public static IServiceCollection AddUiNotifier(this IServiceCollection services)
         {
             var disabled = Environment.GetEnvironmentVariable("NOTIFICATIONS_DISABLED");
-            if (string.Equals(disabled, "true", StringComparison.OrdinalIgnoreCase))
+            if (bool.TryParse(disabled?.Trim(), out var isDisabled) && isDisabled)
             {
                 services.AddSingleton<IUiNotifier, SilentUiNotifier>();
                 return services;

--- a/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/tests/Publishing.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -21,6 +21,18 @@ namespace Publishing.Core.Tests
         }
 
         [TestMethod]
+        public void AddUiNotifier_ParsesBooleanWithWhitespace()
+        {
+            var services = new ServiceCollection();
+            Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", "  true  ");
+            services.AddUiNotifier();
+            var provider = services.BuildServiceProvider();
+            var notifier = provider.GetRequiredService<IUiNotifier>();
+            Assert.IsInstanceOfType(notifier, typeof(SilentUiNotifier));
+            Environment.SetEnvironmentVariable("NOTIFICATIONS_DISABLED", null);
+        }
+
+        [TestMethod]
         public void AddUiNotifier_ReturnsPlatformSpecificImplementation()
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- make AddUiNotifier ignore whitespace around `NOTIFICATIONS_DISABLED`
- test that flag with whitespace still uses SilentUiNotifier

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68599b8117188320bf993613238908c1