### PR TITLE
Fix compilation typo in UIResourcesTests

### DIFF
--- a/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
+++ b/src/tests/Publishing.Core.Tests/UIResourcesTests.cs
@@ -13,7 +13,7 @@ public class UIResourcesTests
     {
         var baseRes = new ResourceManager(
             "Publishing.Resources.Resources",
-            typeof(loginForm).Assembly);
+            typeof(LoginForm).Assembly);
         foreach (var entry in baseRes.GetResourceSet(System.Globalization.CultureInfo.InvariantCulture, true, true)!)
         {
             // Skip entries without a valid string key to avoid nullable warnings.


### PR DESCRIPTION
## Summary
- fix the type reference in `UIResourcesTests`

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859a5921a4c8320bac37ee5da332b89