### PR TITLE
Fix cross-target WinForms code and remove missing package refs

### DIFF
--- a/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
@@ -1,3 +1,4 @@
+#if NET6_0_WINDOWS
 using System.Windows.Forms;
 
 namespace Publishing.Services
@@ -30,3 +31,4 @@ namespace Publishing.Services
     }
 #pragma warning restore PUB002
 }
+#endif

--- a/src/Publishing.UI/Publishing.UI.csproj
+++ b/src/Publishing.UI/Publishing.UI.csproj
@@ -36,7 +36,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Publishing.Analyzers" Version="1.1.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json">

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -16,6 +16,5 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Publishing.Analyzers" Version="1.1.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -28,6 +28,5 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-    <PackageReference Include="Publishing.Analyzers" Version="1.1.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.UI.Tests/MessageBoxUiTests.cs
+++ b/src/tests/Publishing.UI.Tests/MessageBoxUiTests.cs
@@ -11,16 +11,16 @@ namespace Publishing.UI.Tests;
 [TestCategory("UI")]
 public class MessageBoxUiTests
 {
-    // In Appium.WebDriver versions referenced by this project the WindowsDriver
-    // type isn't generic, so use the non-generic form for the session instance.
-    private OpenQA.Selenium.Appium.Windows.WindowsDriver? _session;
+    // Appium.WebDriver exposes a generic WindowsDriver<T> which provides
+    // FindElementBy* helper methods on the WindowsElement type.
+    private WindowsDriver<WindowsElement>? _session;
 
     [TestInitialize]
     public void Setup()
     {
         var opts = new AppiumOptions();
         opts.AddAdditionalAppiumOption(MobileCapabilityType.App, "Publishing.UI.exe");
-        _session = new OpenQA.Selenium.Appium.Windows.WindowsDriver(new Uri("http://127.0.0.1:4723"), opts);
+        _session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
     }
 
     [TestCleanup]


### PR DESCRIPTION
## Summary
- conditionally compile WinForms notifier only on Windows
- use generic WindowsDriver type in UI tests
- drop unused Publishing.Analyzers package references

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test Publishing.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f0f918cc8320ab0c2d6fe96d684e