### PR TITLE
Fix notifier registration and update UI tests

### DIFF
--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -66,7 +66,7 @@ namespace Publishing
             services.AddScoped<IPriceCalculator, PriceCalculator>();
             services.AddScoped<IOrderInputValidator, OrderInputValidator>();
             services.AddScoped<IRoleService, RoleService>();
-            services.AddSingleton<IUiNotifier, MessageBoxNotifier>();
+            services.AddSingleton<IUiNotifier, Publishing.Services.MessageBoxNotifier>();
             services.AddScoped<IErrorHandler, ErrorHandler>();
             services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
             services.AddSingleton<IUserSession, UserSession>();

--- a/src/tests/Publishing.UI.Tests/MessageBoxUiTests.cs
+++ b/src/tests/Publishing.UI.Tests/MessageBoxUiTests.cs
@@ -11,16 +11,16 @@ namespace Publishing.UI.Tests;
 [TestCategory("UI")]
 public class MessageBoxUiTests
 {
-    // Appium.WebDriver exposes a generic WindowsDriver<T> which provides
-    // FindElementBy* helper methods on the WindowsElement type.
-    private WindowsDriver<WindowsElement>? _session;
+    // When using the non-generic WinAppDriver bindings we keep a simple driver
+    // reference without the WindowsElement generic parameter.
+    private WindowsDriver? _session;
 
     [TestInitialize]
     public void Setup()
     {
         var opts = new AppiumOptions();
         opts.AddAdditionalAppiumOption(MobileCapabilityType.App, "Publishing.UI.exe");
-        _session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), opts);
+        _session = new WindowsDriver(new Uri("http://127.0.0.1:4723"), opts);
     }
 
     [TestCleanup]


### PR DESCRIPTION
## Summary
- fix the DI registration for `MessageBoxNotifier`
- update UI tests to use non-generic `WindowsDriver`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f308313083209e03b7c36caa443d