### PR TITLE
Fix build issues

### DIFF
--- a/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
@@ -1,4 +1,4 @@
-#if NET6_0_WINDOWS
+#if WINDOWS
 using System.Windows.Forms;
 
 namespace Publishing.Services

--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -8,10 +8,8 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Use analyzer testing library compatible with .NET 6 -->
+    <!-- Roslyn libraries used directly for analyzer tests -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />


### PR DESCRIPTION
## Summary
- define Windows preprocessor constant correctly
- replace external analyzer testing library with custom helper

## Testing
- `dotnet test Publishing.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859fbbb900c83209870505929d13fab