### PR TITLE
Fix analyzer tests project reference

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
+++ b/src/tests/Publishing.Analyzers.Tests/Publishing.Analyzers.Tests.csproj
@@ -15,4 +15,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Publishing.Analyzers/Publishing.Analyzers.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- ensure analyzer tests reference `Publishing.Analyzers`

## Testing
- `dotnet build Publishing.sln -c Debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fd5ca9848320873f39521cb7273f