### PR TITLE
Fix analyzer test expected column

### DIFF
--- a/src/tests/Publishing.Analyzers.Tests/ForbiddenApiAnalyzerTests.cs
+++ b/src/tests/Publishing.Analyzers.Tests/ForbiddenApiAnalyzerTests.cs
@@ -57,7 +57,7 @@ public class ForbiddenApiAnalyzerTests
     public async Task NotifyIconShowBalloonTip_ProducesDiagnostic()
     {
         var code = "using System.Windows.Forms; class C{ void M(){ new NotifyIcon().ShowBalloonTip(1); }}";
-        await VerifyAsync(code, (ForbiddenApiAnalyzer.DiagnosticId, 1, 63));
+        await VerifyAsync(code, (ForbiddenApiAnalyzer.DiagnosticId, 1, 65));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- correct the expected diagnostic column in `NotifyIconShowBalloonTip_ProducesDiagnostic`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0013e2a08320bc03570a39b572be