### PR TITLE
Add Publishing.Services to Docker builds

### DIFF
--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"
 COPY src/Publishing.Application/.    "Publishing.Application/"
+COPY src/Publishing.Services/.       "Publishing.Services/"
 
 # 1.2) Copy and restore ApiGateway itself
 COPY src/ApiGateway/. "ApiGateway/"

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"
 COPY src/Publishing.Application/.    "Publishing.Application/"
+COPY src/Publishing.Services/.       "Publishing.Services/"
 
 # 1.2) Copy and restore Orders.Service itself
 COPY src/Publishing.Orders.Service/. "Publishing.Orders.Service/"

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"
 COPY src/Publishing.Application/.    "Publishing.Application/"
+COPY src/Publishing.Services/.       "Publishing.Services/"
 
 # 1.2) Copy and restore Organization.Service itself
 COPY src/Publishing.Organization.Service/. "Publishing.Organization.Service/"

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"
 COPY src/Publishing.Application/.    "Publishing.Application/"
+COPY src/Publishing.Services/.       "Publishing.Services/"
 
 # 1.2) Copy and restore Profile.Service itself
 COPY src/Publishing.Profile.Service/. "Publishing.Profile.Service/"


### PR DESCRIPTION
## Summary
- ensure Publishing.Services project is copied into each Docker image

## Testing
- `docker-compose build organization` *(fails: command not found)*
- `dotnet build Publishing.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa67bae188320a4c5d656dd4c68c5