### PR TITLE
Fix Organization.Service build errors

### DIFF
--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.IdentityModel.Tokens;
@@ -20,7 +19,6 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Infrastructure.Repositories;
-using Publishing.Infrastructure;
 using Publishing.AppLayer.Validators;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -76,7 +74,7 @@ builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
-builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddScoped<Publishing.Core.Interfaces.ILogger, LoggerService>();
 builder.Services.AddSingleton<IUiNotifier, ConsoleUiNotifier>();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Publishing.Core\Publishing.Core.csproj" />
     <ProjectReference Include="..\Publishing.Infrastructure\Publishing.Infrastructure.csproj" />
     <ProjectReference Include="..\Publishing.Services\Publishing.Services.csproj" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />


### PR DESCRIPTION
## Summary
- clean up duplicate using directives
- use fully-qualified logger interface
- add FluentValidation DI package to Organization.Service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa899c4388320a78081a83182d8f3