### PR TITLE
Fix organization service build

### DIFF
--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -19,6 +19,7 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Infrastructure.Repositories;
+using Publishing.Infrastructure;
 using Publishing.AppLayer.Validators;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## Summary
- add `Publishing.Infrastructure` namespace in `Publishing.Organization.Service` so the build can find infrastructure types

## Testing
- `dotnet format --no-restore --verify-no-changes` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa9fcc3ac8320b7781e84bab7c0d7