### PR TITLE
Fix DI setup for orders and profile services

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -76,7 +75,7 @@ builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
-builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddScoped<Publishing.Core.Interfaces.ILogger, LoggerService>();
 builder.Services.AddSingleton<IUiNotifier, ConsoleUiNotifier>();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Publishing.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -76,7 +75,7 @@ builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
 builder.Services.AddTransient<IDbContext, DapperDbContext>();
 builder.Services.AddScoped<IDbHelper, DbHelper>();
-builder.Services.AddScoped<ILogger, LoggerService>();
+builder.Services.AddScoped<Publishing.Core.Interfaces.ILogger, LoggerService>();
 builder.Services.AddSingleton<IUiNotifier, ConsoleUiNotifier>();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
     <ProjectReference Include="..\Publishing.Application\Publishing.Application.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add FluentValidation DI package to Orders and Profile services
- remove duplicate using directives
- register logger services with full namespace

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aac443308832082964833f70dd17f