### PR TITLE
Fix invalid namespace reference

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using OpenTelemetry.Trace;
 using Publishing.Services;
-using Publishing.Services.Jwt;
 using Publishing.Core.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## Summary
- remove invalid `Publishing.Services.Jwt` using statement

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ab0b843d48320a018ffcb0a96acb5