### PR TITLE
Fix DI error in ExceptionHandlingMiddleware

### DIFF
--- a/src/Publishing.Services/ErrorHandling/ExceptionHandlingMiddleware.cs
+++ b/src/Publishing.Services/ErrorHandling/ExceptionHandlingMiddleware.cs
@@ -2,18 +2,17 @@ using System;
 using System.Threading.Tasks;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Publishing.Services;
 
 public class ExceptionHandlingMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly IErrorHandler _handler;
 
-    public ExceptionHandlingMiddleware(RequestDelegate next, IErrorHandler handler)
+    public ExceptionHandlingMiddleware(RequestDelegate next)
     {
         _next = next;
-        _handler = handler;
     }
 
     public async Task Invoke(HttpContext context)
@@ -24,7 +23,8 @@ public class ExceptionHandlingMiddleware
         }
         catch (Exception ex)
         {
-            _handler.Handle(ex);
+            var handler = context.RequestServices.GetRequiredService<IErrorHandler>();
+            handler.Handle(ex);
             if (!context.Response.HasStarted)
             {
                 context.Response.StatusCode = 500;


### PR DESCRIPTION
## Summary
- resolve scoped service for error handling per request instead of at startup

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac0eb755883209f4b5b5b5e583398