### PR TITLE
Fix DI setup and health checks

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -108,10 +108,11 @@ if (string.IsNullOrWhiteSpace(conn))
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
 
-builder.Services
+var healthChecks = builder.Services
     .AddHealthChecks()
-    .AddDatabaseHealthChecks()
-    .AddRabbitMQ(rabbitConnectionString: rabbitConn);
+    .AddDatabaseHealthChecks();
+if (!string.IsNullOrWhiteSpace(rabbitConn))
+    healthChecks.AddRabbitMQ(rabbitConnectionString: rabbitConn);
 
 var app = builder.Build();
 

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -70,6 +70,12 @@ builder.Services.AddAutoMapper(typeof(ProfileProfile).Assembly);
 builder.Services.AddValidatorsFromAssemblyContaining<EmailValidator>();
 builder.Services.AddTransient<PhoneFaxValidator>();
 builder.Services.AddTransient<IValidator<string>, EmailValidator>();
+builder.Services.AddScoped<IOrderRepository, OrderRepository>();
+builder.Services.AddScoped<IPrinteryRepository, PrinteryRepository>();
+builder.Services.AddScoped<IOrganizationRepository, OrganizationRepository>();
+builder.Services.AddScoped<IDiscountPolicy, StandardDiscountPolicy>();
+builder.Services.AddScoped<IPriceCalculator, PriceCalculator>();
+builder.Services.AddScoped<IDateTimeProvider, SystemDateTimeProvider>();
 builder.Services.AddScoped<IProfileRepository, ProfileRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
@@ -101,10 +107,11 @@ if (string.IsNullOrWhiteSpace(conn))
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
 
-builder.Services
+var healthChecks = builder.Services
     .AddHealthChecks()
-    .AddDatabaseHealthChecks()
-    .AddRabbitMQ(rabbitConnectionString: rabbitConn);
+    .AddDatabaseHealthChecks();
+if (!string.IsNullOrWhiteSpace(rabbitConn))
+    healthChecks.AddRabbitMQ(rabbitConnectionString: rabbitConn);
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- ensure RabbitMQ health checks only run when configured
- register repositories and utilities needed by MediatR handlers in Profile service

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad1260b008320946d9316356d671f