### PR TITLE
Configure OpenTelemetry service names

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
 
@@ -45,7 +46,9 @@ builder.Services.AddSingleton<IUiNotifier, ConsoleUiNotifier>();
 builder.Services.AddScoped<IErrorHandler, ErrorHandler>();
 builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IJwtFactory, JwtFactory>();
-builder.Services.AddOpenTelemetry().WithTracing(b =>
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService(builder.Environment.ApplicationName))
+    .WithTracing(b =>
     b.AddAspNetCoreInstrumentation()
      .AddHttpClientInstrumentation()
      .AddConsoleExporter());

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -8,6 +8,7 @@ using HealthChecks.RabbitMQ;
 using Microsoft.OpenApi.Models;
 using System;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 using MediatR;
 using Publishing.AppLayer.Handlers;
 using Publishing.AppLayer.Mapping;
@@ -93,7 +94,9 @@ if (string.IsNullOrWhiteSpace(rabbitConn))
 else
     builder.Services.AddSingleton<IOrderEventsPublisher>(sp =>
         new RabbitOrderEventsPublisher(rabbitConn));
-builder.Services.AddOpenTelemetry().WithTracing(b =>
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService(builder.Environment.ApplicationName))
+    .WithTracing(b =>
     b.AddAspNetCoreInstrumentation()
      .AddHttpClientInstrumentation()
      .AddEntityFrameworkCoreInstrumentation()

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.OpenApi.Models;
 using System;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 using MediatR;
 using Publishing.AppLayer.Handlers;
 using Publishing.AppLayer.Mapping;
@@ -92,7 +93,9 @@ if (string.IsNullOrWhiteSpace(rabbitConn))
 else
     builder.Services.AddSingleton<IOrderEventsPublisher>(sp =>
         new RabbitOrderEventsPublisher(rabbitConn));
-builder.Services.AddOpenTelemetry().WithTracing(b =>
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService(builder.Environment.ApplicationName))
+    .WithTracing(b =>
     b.AddAspNetCoreInstrumentation()
      .AddHttpClientInstrumentation()
      .AddEntityFrameworkCoreInstrumentation()

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -9,6 +9,7 @@ using HealthChecks.RabbitMQ;
 using Microsoft.OpenApi.Models;
 using System;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
 using MediatR;
 using Publishing.AppLayer.Handlers;
 using Publishing.AppLayer.Mapping;
@@ -92,7 +93,9 @@ if (string.IsNullOrWhiteSpace(rabbitConn))
 else
     builder.Services.AddSingleton<IOrderEventsPublisher>(sp =>
         new RabbitOrderEventsPublisher(rabbitConn));
-builder.Services.AddOpenTelemetry().WithTracing(b =>
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService(builder.Environment.ApplicationName))
+    .WithTracing(b =>
     b.AddAspNetCoreInstrumentation()
      .AddHttpClientInstrumentation()
      .AddEntityFrameworkCoreInstrumentation()


### PR DESCRIPTION
## Summary
- register OpenTelemetry.Resources in gateway and services
- configure resource builder with application name for tracing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad52803d883208d8579fb260eaf3c