### PR TITLE
Fix project references for ApiGateway

### DIFF
--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,6 +6,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+    <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,6 +30,6 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+    <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- use backslashes in project references to ApiGateway

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbd5615008320b5798605b087453d