### PR TITLE
Fix mapping profile imports

### DIFF
--- a/src/Publishing.Application/Mapping/OrderProfile.cs
+++ b/src/Publishing.Application/Mapping/OrderProfile.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Publishing.Core.Domain;
 using Publishing.Core.DTOs;
 using Publishing.AppLayer.Commands;
+using Publishing.Core.Commands;
 
 namespace Publishing.AppLayer.Mapping;
 


### PR DESCRIPTION
## Summary
- ensure `OrderProfile` can see `UpdateOrderCommand` by including the proper namespace

## Testing
- `dotnet test Publishing.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cca3a3dc483208826a9c5e5b76021