### PR TITLE
Enhance resiliency features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,12 @@
 - Analyzer rule `PUB002` forbids calls to `MessageBox.Show` and `NotifyIcon.ShowBalloonTip`.
 - Analyzer rule `PUB003` detects `#if WINDOWS` directives.
 
+## [1.2.0] - 2025-06-26
+### Added
+- Consul registration now supports health checks, tags and metadata and runs asynchronously.
+- RabbitMQ queues are durable and include the `traceparent` header.
+- Redis now runs with a replica for high availability.
+- Order saga tracks created order IDs to perform targeted compensation.
+
 ### Removed
 - Legacy `PUB001` rule and tray balloon notifier implementation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,14 @@ services:
     networks:
       - micro-net
 
+  cache-replica:
+    image: redis:alpine
+    command: redis-server --slaveof cache 6379
+    depends_on:
+      - cache
+    networks:
+      - micro-net
+
   rabbit:
     image: rabbitmq:3-management
     ports:

--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -108,7 +108,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseSwagger();
 app.UseSwaggerUI();
-app.RegisterWithConsul(app.Lifetime, app.Configuration);
+await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 await app.UseOcelot();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/Publishing.Core/Interfaces/IOrderRepository.cs
+++ b/src/Publishing.Core/Interfaces/IOrderRepository.cs
@@ -6,7 +6,7 @@ namespace Publishing.Core.Interfaces
 {
     public interface IOrderRepository
     {
-        Task SaveAsync(Order order);
+        Task<int> SaveAsync(Order order);
 
         Task UpdateExpiredAsync();
 

--- a/src/Publishing.Infrastructure/ConsulExtensions.cs
+++ b/src/Publishing.Infrastructure/ConsulExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
 
 namespace Publishing.Infrastructure;
 
@@ -17,18 +18,46 @@ public static class ConsulExtensions
         return services;
     }
 
-    public static void RegisterWithConsul(this IApplicationBuilder app, IHostApplicationLifetime lifetime, IConfiguration configuration)
+    public static async Task RegisterWithConsulAsync(this IApplicationBuilder app, IHostApplicationLifetime lifetime, IConfiguration configuration)
     {
         var consul = app.ApplicationServices.GetRequiredService<IConsulClient>();
         var serviceId = $"{configuration["SERVICE_NAME"]}-{Guid.NewGuid()}";
+
+        var tags = configuration["SERVICE_TAGS"]?.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        var metaPairs = configuration["SERVICE_META"]?.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        Dictionary<string, string>? meta = null;
+        if (metaPairs != null && metaPairs.Length > 0)
+        {
+            meta = new Dictionary<string, string>();
+            foreach (var pair in metaPairs)
+            {
+                var kv = pair.Split('=', 2);
+                if (kv.Length == 2)
+                    meta[kv[0]] = kv[1];
+            }
+        }
+
+        var address = configuration["SERVICE_ADDRESS"]!;
+        var port = int.Parse(configuration["SERVICE_PORT"] ?? "80");
+        var check = new AgentServiceCheck
+        {
+            HTTP = $"http://{address}:{port}/health",
+            Interval = TimeSpan.FromSeconds(10),
+            DeregisterCriticalServiceAfter = TimeSpan.FromSeconds(30)
+        };
+
         var registration = new AgentServiceRegistration
         {
             ID = serviceId,
             Name = configuration["SERVICE_NAME"],
-            Address = configuration["SERVICE_ADDRESS"],
-            Port = int.Parse(configuration["SERVICE_PORT"] ?? "80")
+            Address = address,
+            Port = port,
+            Tags = tags,
+            Meta = meta,
+            Checks = new[] { check }
         };
-        consul.Agent.ServiceRegister(registration).Wait();
-        lifetime.ApplicationStopping.Register(() => consul.Agent.ServiceDeregister(registration.ID).Wait());
+
+        await consul.Agent.ServiceRegister(registration);
+        lifetime.ApplicationStopping.Register(() => consul.Agent.ServiceDeregister(registration.ID).GetAwaiter().GetResult());
     }
 }

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -190,7 +190,7 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-app.RegisterWithConsul(app.Lifetime, app.Configuration);
+await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/Publishing.Orders.Service/Sagas/OrderSaga.cs
+++ b/src/Publishing.Orders.Service/Sagas/OrderSaga.cs
@@ -32,7 +32,7 @@ public class OrderSaga : IOrderSaga
             Price = dto.Price
         };
 
-        await _orders.SaveAsync(order);
+        var orderId = await _orders.SaveAsync(order);
         try
         {
             var profile = _factory.CreateClient("profile-updates");
@@ -45,7 +45,7 @@ public class OrderSaga : IOrderSaga
         }
         catch
         {
-            await _orders.DeleteLatestAsync(dto.PersonId);
+            await _orders.DeleteAsync(orderId);
             throw;
         }
     }

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -144,7 +144,7 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-app.RegisterWithConsul(app.Lifetime, app.Configuration);
+await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 
 // Map health check endpoint so Docker can check container status

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -144,7 +144,7 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-app.RegisterWithConsul(app.Lifetime, app.Configuration);
+await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using System.Diagnostics;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Publishing.Core.DTOs;
@@ -21,8 +22,9 @@ public class RabbitOrganizationEventsPublisher : IOrganizationEventsPublisher, I
         _channel = _connection.CreateModel();
         _channel.ExchangeDeclare("organizations", ExchangeType.Topic, durable: true);
 
-        var queue = _channel.QueueDeclare().QueueName;
-        _channel.QueueBind(queue, "organizations", "organization.updated");
+        var queueName = $"{Environment.GetEnvironmentVariable("SERVICE_NAME")}-organizations";
+        _channel.QueueDeclare(queueName, durable: true, exclusive: false, autoDelete: false);
+        _channel.QueueBind(queueName, "organizations", "organization.updated");
         var consumer = new EventingBasicConsumer(_channel);
         consumer.Received += (s, e) =>
         {
@@ -30,14 +32,20 @@ public class RabbitOrganizationEventsPublisher : IOrganizationEventsPublisher, I
             var organization = JsonSerializer.Deserialize<OrganizationDto>(message);
             OrganizationUpdated?.Invoke(organization!);
         };
-        _channel.BasicConsume(queue, autoAck: true, consumer);
+        _channel.BasicConsume(queueName, autoAck: true, consumer);
     }
 
     public void PublishOrganizationUpdated(OrganizationDto organization)
     {
         OrganizationUpdated?.Invoke(organization);
         var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(organization));
-        _channel.BasicPublish("organizations", "organization.updated", null, body);
+        var props = _channel.CreateBasicProperties();
+        props.DeliveryMode = 2;
+        props.Headers = new Dictionary<string, object>
+        {
+            ["traceparent"] = Activity.Current?.Id ?? string.Empty
+        };
+        _channel.BasicPublish("organizations", "organization.updated", props, body);
     }
 
     public void Dispose()

--- a/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/CreateOrderHandlerTests.cs
@@ -24,10 +24,10 @@ namespace Publishing.Core.Tests
         private class StubOrderRepository : IOrderRepository
         {
             public Order? SavedOrder { get; private set; }
-            public Task SaveAsync(Order order)
+            public Task<int> SaveAsync(Order order)
             {
                 SavedOrder = order;
-                return Task.CompletedTask;
+                return Task.FromResult(1);
             }
             public Task UpdateExpiredAsync() => Task.CompletedTask;
             public Task<DataTable> GetActiveAsync() => Task.FromResult(new DataTable());


### PR DESCRIPTION
## Summary
- add async Consul registration with health checks, tags and metadata
- store order ID in saga to delete the exact record on rollback
- make RabbitMQ events durable and propagate trace context
- run a Redis replica container for availability
- document the improvements

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccba1d1488320ab94a71fb2e59a22