### PR TITLE
Fix compilation errors in Publishers and tests

### DIFF
--- a/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
@@ -92,7 +92,7 @@ namespace Publishing.Infrastructure.Repositories
             }
             else
             {
-                orderId = await _db.QuerySingleAsync<int>(sql + "; SELECT CAST(SCOPE_IDENTITY() as int);", new
+                var idsSingle = await _db.QueryAsync<int>(sql + "; SELECT CAST(SCOPE_IDENTITY() as int);", new
                 {
                     ProdId = prodId,
                     order.PersonId,
@@ -103,6 +103,7 @@ namespace Publishing.Infrastructure.Repositories
                     order.Tirage,
                     order.Price
                 });
+                orderId = idsSingle.First();
             }
 
             return orderId;

--- a/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Collections.Generic;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Publishing.Core.DTOs;

--- a/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 using System.Diagnostics;
+using System.Collections.Generic;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Publishing.Core.DTOs;

--- a/src/Publishing.Services/Events/RabbitProfileEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitProfileEventsPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 using System.Diagnostics;
+using System.Collections.Generic;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Publishing.Core.DTOs;

--- a/src/tests/Publishing.Core.Tests/UpdateOrganizationHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/UpdateOrganizationHandlerTests.cs
@@ -70,12 +70,22 @@ public class UpdateOrganizationHandlerTests
         public void NotifyError(string message, string? details = null) { }
     }
 
+    private class StubEvents : IOrganizationEventsPublisher
+    {
+        public event Action<OrganizationDto>? OrganizationUpdated;
+
+        public void PublishOrganizationUpdated(OrganizationDto organization)
+        {
+            OrganizationUpdated?.Invoke(organization);
+        }
+    }
+
     [TestMethod]
     public async Task Handle_ExistingName_Updates()
     {
         var repo = new StubRepo { ExistingName = "org" };
         var uow = new StubUnitOfWork();
-        var handler = new UpdateOrganizationHandler(repo, new InlineValidator<UpdateOrganizationCommand>(), uow, new StubNotifier());
+        var handler = new UpdateOrganizationHandler(repo, new InlineValidator<UpdateOrganizationCommand>(), uow, new StubNotifier(), new StubEvents());
         var cmd = new UpdateOrganizationCommand { Id = "1", Name = "org" };
         await handler.Handle(cmd, CancellationToken.None);
         Assert.IsNotNull(repo.Updated);
@@ -87,7 +97,7 @@ public class UpdateOrganizationHandlerTests
     {
         var repo = new StubRepo { ExistingName = "other" };
         var uow = new StubUnitOfWork();
-        var handler = new UpdateOrganizationHandler(repo, new InlineValidator<UpdateOrganizationCommand>(), uow, new StubNotifier());
+        var handler = new UpdateOrganizationHandler(repo, new InlineValidator<UpdateOrganizationCommand>(), uow, new StubNotifier(), new StubEvents());
         var cmd = new UpdateOrganizationCommand { Id = "2", Name = "org" };
         await handler.Handle(cmd, CancellationToken.None);
         Assert.IsNotNull(repo.Created);

--- a/src/tests/Publishing.Core.Tests/UpdateProfileHandlerTests.cs
+++ b/src/tests/Publishing.Core.Tests/UpdateProfileHandlerTests.cs
@@ -70,12 +70,21 @@ public class UpdateProfileHandlerTests
         public void NotifyError(string message, string? details = null) { }
     }
 
+    private class StubEvents : IProfileEventsPublisher
+    {
+        public event Action<ProfileDto>? ProfileUpdated;
+        public void PublishProfileUpdated(ProfileDto profile)
+        {
+            ProfileUpdated?.Invoke(profile);
+        }
+    }
+
     [TestMethod]
     public async Task Handle_EmailNotExists_Updates()
     {
         var repo = new StubRepo();
         var uow = new StubUnitOfWork();
-        var handler = new UpdateProfileHandler(repo, new InlineValidator<UpdateProfileCommand>(), uow, new StubNotifier());
+        var handler = new UpdateProfileHandler(repo, new InlineValidator<UpdateProfileCommand>(), uow, new StubNotifier(), new StubEvents());
         var cmd = new UpdateProfileCommand { Id = "1", Email = "e@e.com" };
         await handler.Handle(cmd, CancellationToken.None);
         Assert.IsNotNull(repo.Updated);
@@ -87,7 +96,7 @@ public class UpdateProfileHandlerTests
     {
         var repo = new StubRepo { EmailExists = true };
         var uow = new StubUnitOfWork();
-        var handler = new UpdateProfileHandler(repo, new InlineValidator<UpdateProfileCommand>(), uow, new StubNotifier());
+        var handler = new UpdateProfileHandler(repo, new InlineValidator<UpdateProfileCommand>(), uow, new StubNotifier(), new StubEvents());
         var cmd = new UpdateProfileCommand { Id = "1", Email = "e@e.com" };
         await handler.Handle(cmd, CancellationToken.None);
     }


### PR DESCRIPTION
## Summary
- import `System.Collections.Generic` for RabbitMQ event publishers
- fix `OrderRepository` build error by using `QueryAsync` and `First()`
- update core tests with stub event publishers to match handler constructors

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ccfa21c608320844247d228624336