### PR TITLE
Fix project references in test csproj files

### DIFF
--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-  <!-- Project path should use forward slashes to work on all platforms -->
-  <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+    <!-- Use backslashes to avoid path resolution issues on Windows -->
+    <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-      <!-- Project path should use forward slashes to work on all platforms -->
-      <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+        <!-- Use backslashes to avoid path resolution issues on Windows -->
+        <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix NuGet restore errors in test projects by using Windows-style path separators

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd32b7eec83208d9e46221b481cf1