### PR TITLE
Fix project references for Linux

### DIFF
--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <!-- Use backslashes to avoid path resolution issues on Windows -->
-    <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
+    <!-- Use forward slashes so that the project restores correctly on all platforms -->
+    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-        <!-- Use backslashes to avoid path resolution issues on Windows -->
-        <ProjectReference Include="..\..\ApiGateway\ApiGateway.csproj" />
+        <!-- Use forward slashes so that the project restores correctly on all platforms -->
+        <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix project references to ApiGateway to be platform-agnostic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd422d3788320851bed55e0314605