### PR TITLE
Add TTL for aggregation cache

### DIFF
--- a/src/ApiGateway/Controllers/AggregationController.cs
+++ b/src/ApiGateway/Controllers/AggregationController.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using Publishing.Core.DTOs;
 using Microsoft.Extensions.Caching.Distributed;
 using System.Text.Json;
+using System;
 
 namespace ApiGateway.Controllers;
 
@@ -46,7 +47,11 @@ public class AggregationController : ControllerBase
             Profile = profileTask.Result,
             Organization = orgTask.Result
         };
-        await _cache.SetStringAsync($"agg_{id}", JsonSerializer.Serialize(result));
+        var options = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1)
+        };
+        await _cache.SetStringAsync($"agg_{id}", JsonSerializer.Serialize(result), options);
         return Ok(result);
     }
 }

--- a/src/ApiGateway/README.md
+++ b/src/ApiGateway/README.md
@@ -9,4 +9,4 @@ dotnet run --project ApiGateway.csproj
 ```
 
 The gateway exposes a health endpoint at `/health`. Swagger for each service is reachable via `/orders/swagger`, `/profile/swagger` and `/organization/swagger`.
-Requests are cached with Redis, traced via OpenTelemetry and secured using JWT bearer authentication.
+Requests are cached with Redis, traced via OpenTelemetry and secured using JWT bearer authentication. Cached responses expire after one minute.

--- a/src/tests/Publishing.Integration.Tests/AggregationCacheTests.cs
+++ b/src/tests/Publishing.Integration.Tests/AggregationCacheTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ApiGateway.Controllers;
+using Microsoft.Extensions.Caching.Distributed;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Net.Http;
+using System.Net;
+using System.Collections.Generic;
+using System;
+
+namespace Publishing.Integration.Tests;
+
+[TestClass]
+public class AggregationCacheTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly string _content;
+        public StubHandler(string content) => _content = content;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_content) });
+    }
+
+    private class StubFactory : IHttpClientFactory
+    {
+        private readonly IDictionary<string, HttpClient> _clients;
+        public StubFactory(IDictionary<string, HttpClient> clients) => _clients = clients;
+        public HttpClient CreateClient(string name) => _clients[name];
+    }
+
+    private class CaptureCache : IDistributedCache
+    {
+        public DistributedCacheEntryOptions? Options { get; private set; }
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => Task.FromResult<byte[]?>(null);
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Options = options;
+            return Task.CompletedTask;
+        }
+        public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+        public Task RemoveAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+        public byte[]? Get(string key) => null;
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options) => Options = options;
+        public void Refresh(string key) { }
+        public void Remove(string key) { }
+    }
+
+    [TestMethod]
+    public async Task Get_SetsOneMinuteCacheExpiration()
+    {
+        var clients = new Dictionary<string, HttpClient>
+        {
+            ["orders"] = new HttpClient(new StubHandler("[]")) { BaseAddress = new Uri("http://x") },
+            ["profile"] = new HttpClient(new StubHandler("{}")) { BaseAddress = new Uri("http://x") },
+            ["organization"] = new HttpClient(new StubHandler("{}")) { BaseAddress = new Uri("http://x") }
+        };
+        var factory = new StubFactory(clients);
+        var cache = new CaptureCache();
+        var controller = new AggregationController(factory, cache);
+
+        await controller.Get("1");
+
+        Assert.IsNotNull(cache.Options);
+        Assert.AreEqual(TimeSpan.FromMinutes(1), cache.Options!.AbsoluteExpirationRelativeToNow);
+    }
+}
+


### PR DESCRIPTION
## Summary
- cache aggregated responses for 1 minute
- document TTL in the API Gateway README
- test that `AggregationController` sets expiration when caching

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd62bca00832084e378d09ade7841