### PR TITLE
Fix test project references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,12 @@
 <Project>
+  <PropertyGroup>
+    <!-- Root folder for all project references -->
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+  </PropertyGroup>
+
   <!-- Attach analyzer project as an Analyzer to all projects except the analyzer itself -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Publishing.Analyzers'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)src/Publishing.Analyzers/Publishing.Analyzers.csproj"
+    <ProjectReference Include="$(RepoRoot)src/Publishing.Analyzers/Publishing.Analyzers.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <!-- Use forward slashes so that the project restores correctly on all platforms -->
-    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+    <!-- Reference ApiGateway using RepoRoot for cross-platform compatibility -->
+    <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-        <!-- Use forward slashes so that the project restores correctly on all platforms -->
-        <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+        <!-- Reference ApiGateway using RepoRoot for cross-platform compatibility -->
+        <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- use `RepoRoot` for consistent project reference paths
- update test csproj files to point to `ApiGateway` using `RepoRoot`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd5ad79388320b8793bfadf131912