### PR TITLE
Fix test project references to use RepoRoot

### DIFF
--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <!-- Reference ApiGateway using a relative path for cross-platform compatibility -->
-    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+    <!-- Reference ApiGateway using the RepoRoot property for cross-platform compatibility -->
+    <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-        <!-- Reference ApiGateway using a relative path for cross-platform compatibility -->
-        <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
+        <!-- Reference ApiGateway using the RepoRoot property for cross-platform compatibility -->
+        <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- reference ApiGateway using RepoRoot property in test projects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd9c60d2883209ee5ea68d4faa5f3