### PR TITLE
Add project path validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       run: dotnet tool install --global dotnet-ef --version 6.0.*
     - name: Add dotnet-ef to PATH
       run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+    - name: Validate project paths
+      run: ./tools/validate-project-paths.sh
     - name: Restore
       run: dotnet restore
     - name: Build

--- a/tools/validate-project-paths.sh
+++ b/tools/validate-project-paths.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+missing=0
+repo_root="$(git rev-parse --show-toplevel)"
+
+check_solution() {
+  grep -oE '"[^" ]+\\[^" ]+\.csproj"' Publishing.sln | tr -d '"' | while IFS= read -r path; do
+    path="$(echo "$path" | sed 's|\\|/|g')"
+    if [ ! -f "$path" ]; then
+      echo "Missing solution project path: $path" >&2
+      missing=1
+    fi
+  done
+}
+
+check_csproj() {
+  local csproj="$1"
+  while IFS= read -r ref; do
+    local normalized
+    normalized="$(echo "$ref" | sed 's|\\|/|g')"
+    local fullpath
+    if [[ "$normalized" == \$\(RepoRoot\)* ]]; then
+      normalized="${normalized#\$(RepoRoot)}"
+      fullpath="$repo_root/$normalized"
+    else
+      fullpath="$(dirname "$csproj")/$normalized"
+    fi
+    if [ ! -f "$fullpath" ]; then
+      echo "Missing project reference in $csproj: $normalized" >&2
+      missing=1
+    fi
+  done < <(grep -oP '<ProjectReference\s+Include="\K[^"]+' "$csproj")
+}
+
+check_solution
+
+while IFS= read -r csproj; do
+  check_csproj "$csproj"
+done < <(find . -name '*.csproj')
+
+exit $missing


### PR DESCRIPTION
## Summary
- add `tools/validate-project-paths.sh` to ensure all project references exist
- run validation as part of CI before restoring packages

## Testing
- `./tools/validate-project-paths.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d51b95f2c8320bd541c61418353b0