### PR TITLE
Fix RepoRoot missing in Docker builds

### DIFF
--- a/src/ApiGateway/Dockerfile
+++ b/src/ApiGateway/Dockerfile
@@ -3,6 +3,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
+# Ensure MSBuild can resolve the RepoRoot property
+COPY Directory.Build.props .
+
 # 1.1) Copy dependent projects (code + csproj)
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"

--- a/src/Publishing.Orders.Service/Dockerfile
+++ b/src/Publishing.Orders.Service/Dockerfile
@@ -3,6 +3,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
+# Ensure MSBuild can resolve the RepoRoot property
+COPY Directory.Build.props .
+
 # 1.1) Copy dependent projects (code + csproj)
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"

--- a/src/Publishing.Organization.Service/Dockerfile
+++ b/src/Publishing.Organization.Service/Dockerfile
@@ -3,6 +3,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
+# Ensure MSBuild can resolve the RepoRoot property
+COPY Directory.Build.props .
+
 # 1.1) Copy dependent projects (code + csproj)
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"

--- a/src/Publishing.Profile.Service/Dockerfile
+++ b/src/Publishing.Profile.Service/Dockerfile
@@ -3,6 +3,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
+# Ensure MSBuild can resolve the RepoRoot property
+COPY Directory.Build.props .
+
 # 1.1) Copy dependent projects (code + csproj)
 COPY src/Publishing.Core/.           "Publishing.Core/"
 COPY src/Publishing.Infrastructure/. "Publishing.Infrastructure/"


### PR DESCRIPTION
## Summary
- copy `Directory.Build.props` in each Dockerfile so MSBuild resolves `RepoRoot`

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d61a4739c8320aa887bd9473ebf6d