### PR TITLE
Fix dotnet restore in Docker build

### DIFF
--- a/src/ApiGateway/ApiGateway.csproj
+++ b/src/ApiGateway/ApiGateway.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Ocelot.Provider.Consul" Version="17.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.2-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />


### PR DESCRIPTION
## Summary
- pin Prometheus exporter version to `1.11.0` for .NET 6 compatibility

## Testing
- `docker-compose build organization` *(fails: `docker-compose: command not found`)*
- `dotnet restore src/Publishing.Organization.Service/Publishing.Organization.Service.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d969d3eec8320af151c76d2230f3f