### PR TITLE
Fix project references in tests

### DIFF
--- a/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
+++ b/src/tests/Publishing.E2E.Tests/Publishing.E2E.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <!-- Reference ApiGateway using the RepoRoot property for cross-platform compatibility -->
-    <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
+    <!-- Reference ApiGateway using a relative path for cross-platform compatibility -->
+    <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
+++ b/src/tests/Publishing.Integration.Tests/Publishing.Integration.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="../../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
     <ProjectReference Include="../../Publishing.Core/Publishing.Core.csproj" />
     <ProjectReference Include="../../Publishing.Services/Publishing.Services.csproj" />
-        <!-- Reference ApiGateway using the RepoRoot property for cross-platform compatibility -->
-        <ProjectReference Include="$(RepoRoot)src/ApiGateway/ApiGateway.csproj" />
+        <!-- Reference ApiGateway using a relative path for cross-platform compatibility -->
+        <ProjectReference Include="../../ApiGateway/ApiGateway.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix paths to ApiGateway project in E2E and integration tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da60daf08832086d8d219817fb85b