### PR TITLE
Fix PUB003 analyzer error

### DIFF
--- a/src/Publishing.Services/Publishing.Services.csproj
+++ b/src/Publishing.Services/Publishing.Services.csproj
@@ -15,6 +15,9 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
     <!-- WinForms-specific implementations are included by default -->
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='net6.0-windows'">
+    <Compile Remove="UiNotifications/MessageBoxNotifier.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.31.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.31.0" />

--- a/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
+++ b/src/Publishing.Services/UiNotifications/MessageBoxNotifier.cs
@@ -1,4 +1,3 @@
-#if WINDOWS
 using System.Windows.Forms;
 
 namespace Publishing.Services
@@ -31,4 +30,3 @@ namespace Publishing.Services
     }
 #pragma warning restore PUB002
 }
-#endif


### PR DESCRIPTION
## Summary
- remove `#if WINDOWS` directives from `MessageBoxNotifier`
- compile `MessageBoxNotifier` only for `net6.0-windows`

## Testing
- `dotnet format style --no-restore --verify-no-changes` *(fails: command not found)*
- `dotnet format analyzers --no-restore` *(fails: command not found)*
- `dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults /p:Threshold=90 /p:ThresholdType=line /p:ThresholdStat=total --filter "TestCategory!=UI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db5fd74c48320a55c820330115ae7