### PR TITLE
Fix build by adding runtime instrumentation package

### DIFF
--- a/src/ApiGateway/ApiGateway.csproj
+++ b/src/ApiGateway/ApiGateway.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Ocelot.Provider.Consul" Version="17.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0-rc.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -10,6 +10,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Metrics;
 using Serilog;
 using Publishing.Infrastructure;
+using OpenTelemetry.Instrumentation.Runtime;
 using Publishing.Services;
 using Publishing.Core.Interfaces;
 using ApiGateway.Extensions;

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -27,7 +27,7 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Infrastructure.Repositories;
-using Publishing.Infrastructure;
+using OpenTelemetry.Instrumentation.Runtime;
 using Publishing.AppLayer.Validators;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0-rc.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -23,7 +23,7 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Infrastructure.Repositories;
-using Publishing.Infrastructure;
+using OpenTelemetry.Instrumentation.Runtime;
 using Publishing.AppLayer.Validators;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
+++ b/src/Publishing.Organization.Service/Publishing.Organization.Service.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0-rc.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -24,7 +24,7 @@ using Publishing.Core.Interfaces;
 using Publishing.Core.Services;
 using FluentValidation;
 using Publishing.Infrastructure.Repositories;
-using Publishing.Infrastructure;
+using OpenTelemetry.Instrumentation.Runtime;
 using Publishing.AppLayer.Validators;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
+++ b/src/Publishing.Profile.Service/Publishing.Profile.Service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0-rc.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />


### PR DESCRIPTION
## Summary
- add `OpenTelemetry.Instrumentation.Runtime` package to all services
- reference runtime instrumentation in service startup code

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db7789290832095cbdf7ae4d7cc03