### PR TITLE
Fix build issues for Orders service

### DIFF
--- a/src/Publishing.Core/DTOs/CreateOrderDto.cs
+++ b/src/Publishing.Core/DTOs/CreateOrderDto.cs
@@ -6,6 +6,9 @@ namespace Publishing.Core.DTOs
         public string Name { get; set; } = string.Empty;
         public int Pages { get; set; }
         public int Tirage { get; set; }
+        public DateTime DateStart { get; set; }
+        public DateTime DateFinish { get; set; }
+        public decimal Price { get; set; }
         public string Printery { get; set; } = string.Empty;
         public string PersonId { get; set; } = string.Empty;
     }

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -16,6 +16,7 @@ using MediatR;
 using Publishing.AppLayer.Handlers;
 using Publishing.AppLayer.Mapping;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.Caching.Distributed;
 using Publishing.Orders.Service.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using System.Net.Http;

--- a/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
+++ b/src/Publishing.Orders.Service/Publishing.Orders.Service.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />


### PR DESCRIPTION
## Summary
- include job metadata in CreateOrderDto
- add distributed cache using directive
- reference Microsoft.Extensions.Http.Polly so AddPolicyHandler resolves

## Testing
- `dotnet test src/tests/Publishing.Core.Tests/Publishing.Core.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc11dc53883208eca9b27fcabd17c