### PR TITLE
Fix ApiGateway build by referencing Infrastructure

### DIFF
--- a/src/ApiGateway/ApiGateway.csproj
+++ b/src/ApiGateway/ApiGateway.csproj
@@ -23,5 +23,6 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Consul" Version="1.7.14.7" />
     <ProjectReference Include="../Publishing.Services/Publishing.Services.csproj" />
+    <ProjectReference Include="../Publishing.Infrastructure/Publishing.Infrastructure.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix missing `Publishing.Infrastructure` project reference in `ApiGateway`

## Testing
- `N/A` (dotnet unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_685dc8df9a6c832093a354217ccf8430