### PR TITLE
Fix ApiGateway DI using

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -4,6 +4,7 @@ using Ocelot.Provider.Consul;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using OpenTelemetry.Trace;


### PR DESCRIPTION
## Summary
- add missing `Microsoft.Extensions.DependencyInjection` using directive to ApiGateway

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd7263e048320af2b77d5eff4b79b