### PR TITLE
Fix service startup ordering for RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_started
+      rabbit:
+        condition: service_started
       organization:
         condition: service_healthy
     restart: on-failure
@@ -59,6 +61,8 @@ services:
         condition: service_healthy
       cache:
         condition: service_started
+      rabbit:
+        condition: service_started
       organization:
         condition: service_healthy
     restart: on-failure
@@ -93,6 +97,8 @@ services:
       db:
         condition: service_healthy
       cache:
+        condition: service_started
+      rabbit:
         condition: service_started
     restart: on-failure
     healthcheck:


### PR DESCRIPTION
## Summary
- ensure orders, profile and organization services wait for RabbitMQ

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddfdea7788320854fa12423e0dfae