### PR TITLE
Fix RabbitMQ startup dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       cache:
         condition: service_started
       rabbit:
-        condition: service_started
+        condition: service_healthy
       organization:
         condition: service_healthy
     restart: on-failure
@@ -62,7 +62,7 @@ services:
       cache:
         condition: service_started
       rabbit:
-        condition: service_started
+        condition: service_healthy
       organization:
         condition: service_healthy
     restart: on-failure
@@ -99,7 +99,7 @@ services:
       cache:
         condition: service_started
       rabbit:
-        condition: service_started
+        condition: service_healthy
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
@@ -179,9 +179,15 @@ services:
 
   rabbit:
     image: rabbitmq:3-management
+    hostname: rabbit
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - micro-net
 


### PR DESCRIPTION
## Summary
- ensure services wait for RabbitMQ to be healthy
- add hostname and healthcheck to RabbitMQ service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de19f9f04832094888d091c4b2873