### PR TITLE
Disable Elasticsearch security

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ services reachable directly from the host.
 The API gateway project under `src/ApiGateway` routes requests to the services. Swagger is enabled for each service and the gateway itself at `/swagger`. Health checks are exposed at `/health`. The compose stack also launches **Elasticsearch**, **Kibana**, **Jaeger** and **Prometheus** for centralized logging and tracing.
 Copy `.env.example` to `.env` and adjust the connection strings and JWT settings before starting the stack. Required variables are `SA_PASSWORD`, `ACCEPT_EULA`, `ORDERS_DB_CONN`, `PROFILE_DB_CONN`, `ORGANIZATION_DB_CONN`, `REDIS_CONN`, `RABBIT_CONN`, `CONSUL_URL`, `OIDC_AUTHORITY`, `OIDC_AUDIENCE`, `ELASTIC_URL`, `JWT__Issuer`, `JWT__Audience` and `JWT__SigningKey`.
 Elasticsearch runs on `http://localhost:9200` with Kibana at `http://localhost:5601`. Jaeger UI is available at `http://localhost:16686` and Prometheus at `http://localhost:9090` when using the compose stack.
+Security is disabled for Elasticsearch via `xpack.security.enabled=false` to simplify local development.
 See `docs/kibana.md` for hints on visualising logs with Kibana.
 Keycloak is used as an OAuth2 provider. Import the realm configuration under `keycloak/realm-export.json` with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,6 +207,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
       - "9200:9200"


### PR DESCRIPTION
## Summary
- disable xpack security to allow HTTP connections to Elasticsearch
- document the setting in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df633a524832089c34e372c4c4bdf