### PR TITLE
Improve RabbitMQ connection retry logic

### DIFF
--- a/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrderEventsPublisher.cs
@@ -27,13 +27,10 @@ public class RabbitOrderEventsPublisher : IOrderEventsPublisher, IDisposable
             NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
         };
 
-        var retry = Policy
+        var policy = Policy
             .Handle<Exception>()
-            .WaitAndRetry(3, _ => TimeSpan.FromSeconds(5));
-        var breaker = Policy
-            .Handle<Exception>()
-            .CircuitBreaker(2, TimeSpan.FromSeconds(30));
-        var policy = Policy.Wrap(retry, breaker);
+            .WaitAndRetryForever(_ => TimeSpan.FromSeconds(5),
+                (ex, _) => Console.WriteLine($"RabbitMQ connection failed: {ex.Message}, retrying..."));
 
         try
         {

--- a/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitOrganizationEventsPublisher.cs
@@ -26,13 +26,10 @@ public class RabbitOrganizationEventsPublisher : IOrganizationEventsPublisher, I
             NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
         };
 
-        var retry = Policy
+        var policy = Policy
             .Handle<Exception>()
-            .WaitAndRetry(3, _ => TimeSpan.FromSeconds(5));
-        var breaker = Policy
-            .Handle<Exception>()
-            .CircuitBreaker(2, TimeSpan.FromSeconds(30));
-        var policy = Policy.Wrap(retry, breaker);
+            .WaitAndRetryForever(_ => TimeSpan.FromSeconds(5),
+                (ex, _) => Console.WriteLine($"RabbitMQ connection failed: {ex.Message}, retrying..."));
 
         try
         {

--- a/src/Publishing.Services/Events/RabbitProfileEventsPublisher.cs
+++ b/src/Publishing.Services/Events/RabbitProfileEventsPublisher.cs
@@ -26,13 +26,10 @@ public class RabbitProfileEventsPublisher : IProfileEventsPublisher, IDisposable
             NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
         };
 
-        var retry = Policy
+        var policy = Policy
             .Handle<Exception>()
-            .WaitAndRetry(3, _ => TimeSpan.FromSeconds(5));
-        var breaker = Policy
-            .Handle<Exception>()
-            .CircuitBreaker(2, TimeSpan.FromSeconds(30));
-        var policy = Policy.Wrap(retry, breaker);
+            .WaitAndRetryForever(_ => TimeSpan.FromSeconds(5),
+                (ex, _) => Console.WriteLine($"RabbitMQ connection failed: {ex.Message}, retrying..."));
 
         try
         {


### PR DESCRIPTION
## Summary
- retry RabbitMQ connections indefinitely with logging

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfd1bdd908320a6509ae79d26e884