### PR TITLE
Fix build errors in tests

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -22,6 +22,8 @@ using HealthChecks.Uris;
 using System.Net;
 using System.Net.Http;
 
+namespace ApiGateway;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("ocelot.json", optional: false, reloadOnChange: true);

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using System.Threading;
 using System;


### PR DESCRIPTION
## Summary
- add namespace declaration to ApiGateway `Program.cs`
- include configuration extension namespace in `GatewayAggregationTests`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2dde2d44832080feb96607dabde5