### PR TITLE
Fix configuration setup in integration tests

### DIFF
--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -11,6 +11,7 @@ using System.Text.Encodings.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
@@ -48,7 +49,7 @@ public class GatewayAggregationTests
                 });
                 builder.ConfigureAppConfiguration((ctx, cfg) =>
                 {
-                    cfg.AddInMemoryCollection(new()
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
                     {
                         ["REDIS_CONN"] = "localhost",
                         ["CONSUL_URL"] = "http://consul",


### PR DESCRIPTION
## Summary
- fix configuration dictionary in GatewayAggregationTests

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_685e2ecfbd848320ab61ba458bc24ea7