### PR TITLE
Improve validation messages

### DIFF
--- a/src/Publishing.Application/Validators/CreateOrderCommandValidator.cs
+++ b/src/Publishing.Application/Validators/CreateOrderCommandValidator.cs
@@ -7,12 +7,12 @@ namespace Publishing.AppLayer.Validators
     {
         public CreateOrderCommandValidator()
         {
-            RuleFor(x => x.Pages).GreaterThan(0);
-            RuleFor(x => x.Tirage).GreaterThan(0);
-            RuleFor(x => x.Name).NotEmpty();
-            RuleFor(x => x.Type).NotEmpty();
+            RuleFor(x => x.Pages).GreaterThan(0).WithMessage("Invalid page count");
+            RuleFor(x => x.Tirage).GreaterThan(0).WithMessage("Invalid tirage");
+            RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required");
+            RuleFor(x => x.Type).NotEmpty().WithMessage("Type is required");
             RuleFor(x => x.PersonId).NotEmpty();
-            RuleFor(x => x.Printery).NotEmpty();
+            RuleFor(x => x.Printery).NotEmpty().WithMessage("Printery is required");
         }
     }
 }

--- a/src/Publishing.Application/Validators/EmailValidator.cs
+++ b/src/Publishing.Application/Validators/EmailValidator.cs
@@ -7,7 +7,7 @@ namespace Publishing.AppLayer.Validators
         public EmailValidator()
         {
             RuleFor(x => x)
-                .NotEmpty()
+                .NotEmpty().WithMessage("Email is required")
                 .Matches(@"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$")
                 .WithMessage("Invalid email format");
         }

--- a/src/Publishing.Application/Validators/RegisterUserCommandValidator.cs
+++ b/src/Publishing.Application/Validators/RegisterUserCommandValidator.cs
@@ -7,10 +7,10 @@ public class RegisterUserCommandValidator : AbstractValidator<RegisterUserComman
 {
     public RegisterUserCommandValidator(IValidator<string> emailValidator)
     {
-        RuleFor(x => x.FirstName).NotEmpty();
-        RuleFor(x => x.LastName).NotEmpty();
+        RuleFor(x => x.FirstName).NotEmpty().WithMessage("First name is required");
+        RuleFor(x => x.LastName).NotEmpty().WithMessage("Last name is required");
         RuleFor(x => x.Email).SetValidator(emailValidator);
-        RuleFor(x => x.Status).NotEmpty();
-        RuleFor(x => x.Password).NotEmpty();
+        RuleFor(x => x.Status).NotEmpty().WithMessage("Status is required");
+        RuleFor(x => x.Password).NotEmpty().WithMessage("Password is required");
     }
 }

--- a/src/Publishing.Application/Validators/RegisterUserValidator.cs
+++ b/src/Publishing.Application/Validators/RegisterUserValidator.cs
@@ -8,8 +8,8 @@ namespace Publishing.AppLayer.Validators
         public RegisterUserValidator(IValidator<string> emailValidator)
         {
             RuleFor(x => x.Email).SetValidator(emailValidator);
-            RuleFor(x => x.Status).NotEmpty();
-            RuleFor(x => x.Password).NotEmpty();
+            RuleFor(x => x.Status).NotEmpty().WithMessage("Status is required");
+            RuleFor(x => x.Password).NotEmpty().WithMessage("Password is required");
         }
     }
 }

--- a/src/Publishing.Application/Validators/UpdateOrganizationValidator.cs
+++ b/src/Publishing.Application/Validators/UpdateOrganizationValidator.cs
@@ -7,10 +7,10 @@ namespace Publishing.AppLayer.Validators
     {
         public UpdateOrganizationValidator(IValidator<string> emailValidator, PhoneFaxValidator phoneFaxValidator)
         {
-            RuleFor(x => x.Name).NotEmpty();
+            RuleFor(x => x.Name).NotEmpty().WithMessage("Organization name is required");
             RuleFor(x => x.Email).SetValidator(emailValidator);
-            RuleFor(x => x.Phone).SetValidator(phoneFaxValidator);
-            RuleFor(x => x.Fax).SetValidator(phoneFaxValidator);
+            RuleFor(x => x.Phone).SetValidator(phoneFaxValidator).WithMessage("Invalid phone format");
+            RuleFor(x => x.Fax).SetValidator(phoneFaxValidator).WithMessage("Invalid fax format");
         }
     }
 }

--- a/src/Publishing.Application/Validators/UpdateProfileCommandValidator.cs
+++ b/src/Publishing.Application/Validators/UpdateProfileCommandValidator.cs
@@ -11,8 +11,8 @@ public class UpdateProfileCommandValidator : AbstractValidator<UpdateProfileComm
         {
             RuleFor(x => x.Email!).SetValidator(emailValidator);
         });
-        RuleFor(x => x.Phone).SetValidator(phoneFaxValidator);
-        RuleFor(x => x.Fax).SetValidator(phoneFaxValidator);
+        RuleFor(x => x.Phone).SetValidator(phoneFaxValidator).WithMessage("Invalid phone format");
+        RuleFor(x => x.Fax).SetValidator(phoneFaxValidator).WithMessage("Invalid fax format");
         RuleFor(x => x).Must(HasAnyValue).WithMessage("No data to update");
     }
 

--- a/src/Publishing.Application/Validators/UpdateProfileValidator.cs
+++ b/src/Publishing.Application/Validators/UpdateProfileValidator.cs
@@ -11,8 +11,8 @@ namespace Publishing.AppLayer.Validators
             {
                 RuleFor(x => x.Email!).SetValidator(emailValidator);
             });
-            RuleFor(x => x.Phone).SetValidator(phoneFaxValidator);
-            RuleFor(x => x.Fax).SetValidator(phoneFaxValidator);
+            RuleFor(x => x.Phone).SetValidator(phoneFaxValidator).WithMessage("Invalid phone format");
+            RuleFor(x => x.Fax).SetValidator(phoneFaxValidator).WithMessage("Invalid fax format");
             RuleFor(x => x).Must(HasAnyValue).WithMessage("No data to update");
         }
 

--- a/src/Publishing.Core/Services/OrderInputValidator.cs
+++ b/src/Publishing.Core/Services/OrderInputValidator.cs
@@ -8,12 +8,12 @@ namespace Publishing.Core.Services
     {
         public OrderInputValidator()
         {
-            RuleFor(x => x.Type).NotEmpty();
-            RuleFor(x => x.Name).NotEmpty();
-            RuleFor(x => x.Printery).NotEmpty();
+            RuleFor(x => x.Type).NotEmpty().WithMessage("Type is required");
+            RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required");
+            RuleFor(x => x.Printery).NotEmpty().WithMessage("Printery is required");
             RuleFor(x => x.PersonId).NotEmpty();
-            RuleFor(x => x.Pages).GreaterThan(0);
-            RuleFor(x => x.Tirage).GreaterThan(0);
+            RuleFor(x => x.Pages).GreaterThan(0).WithMessage("Invalid page count");
+            RuleFor(x => x.Tirage).GreaterThan(0).WithMessage("Invalid tirage");
         }
 
         public new void Validate(CreateOrderDto dto)

--- a/src/Publishing.Services/Resources/Notifications.en-US.resx
+++ b/src/Publishing.Services/Resources/Notifications.en-US.resx
@@ -18,4 +18,31 @@
   <data name="WelcomeUser" xml:space="preserve">
     <value>Welcome, {0} ({1})!</value>
   </data>
+  <data name="EmailRequired" xml:space="preserve">
+    <value>Email is required</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="FirstNameRequired" xml:space="preserve">
+    <value>First name is required</value>
+  </data>
+  <data name="LastNameRequired" xml:space="preserve">
+    <value>Last name is required</value>
+  </data>
+  <data name="StatusRequired" xml:space="preserve">
+    <value>Status is required</value>
+  </data>
+  <data name="OrgNameRequired" xml:space="preserve">
+    <value>Organization name is required</value>
+  </data>
+  <data name="InvalidEmailFormat" xml:space="preserve">
+    <value>Invalid email format</value>
+  </data>
+  <data name="InvalidPhoneFormat" xml:space="preserve">
+    <value>Invalid phone format</value>
+  </data>
+  <data name="InvalidFaxFormat" xml:space="preserve">
+    <value>Invalid fax format</value>
+  </data>
 </root>

--- a/src/Publishing.Services/Resources/Notifications.resx
+++ b/src/Publishing.Services/Resources/Notifications.resx
@@ -18,4 +18,31 @@
   <data name="WelcomeUser" xml:space="preserve">
     <value>Welcome, {0} ({1})!</value>
   </data>
+  <data name="EmailRequired" xml:space="preserve">
+    <value>Email is required</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="FirstNameRequired" xml:space="preserve">
+    <value>First name is required</value>
+  </data>
+  <data name="LastNameRequired" xml:space="preserve">
+    <value>Last name is required</value>
+  </data>
+  <data name="StatusRequired" xml:space="preserve">
+    <value>Status is required</value>
+  </data>
+  <data name="OrgNameRequired" xml:space="preserve">
+    <value>Organization name is required</value>
+  </data>
+  <data name="InvalidEmailFormat" xml:space="preserve">
+    <value>Invalid email format</value>
+  </data>
+  <data name="InvalidPhoneFormat" xml:space="preserve">
+    <value>Invalid phone format</value>
+  </data>
+  <data name="InvalidFaxFormat" xml:space="preserve">
+    <value>Invalid fax format</value>
+  </data>
 </root>

--- a/src/Publishing.Services/Resources/Notifications.uk-UA.resx
+++ b/src/Publishing.Services/Resources/Notifications.uk-UA.resx
@@ -18,4 +18,31 @@
   <data name="WelcomeUser" xml:space="preserve">
     <value>Вітаємо, {0} ({1})!</value>
   </data>
+  <data name="EmailRequired" xml:space="preserve">
+    <value>Потрібна електронна пошта</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Потрібен пароль</value>
+  </data>
+  <data name="FirstNameRequired" xml:space="preserve">
+    <value>Потрібне ім'я</value>
+  </data>
+  <data name="LastNameRequired" xml:space="preserve">
+    <value>Потрібне прізвище</value>
+  </data>
+  <data name="StatusRequired" xml:space="preserve">
+    <value>Потрібно вибрати статус</value>
+  </data>
+  <data name="OrgNameRequired" xml:space="preserve">
+    <value>Потрібна назва організації</value>
+  </data>
+  <data name="InvalidEmailFormat" xml:space="preserve">
+    <value>Некоректний формат електронної пошти</value>
+  </data>
+  <data name="InvalidPhoneFormat" xml:space="preserve">
+    <value>Некоректний формат телефону</value>
+  </data>
+  <data name="InvalidFaxFormat" xml:space="preserve">
+    <value>Некоректний формат факсу</value>
+  </data>
 </root>

--- a/src/Publishing.UI/Forms/AddOrderForm.cs
+++ b/src/Publishing.UI/Forms/AddOrderForm.cs
@@ -127,6 +127,22 @@ namespace Publishing
                 PersonId = _session.UserId
             };
 
+            if (string.IsNullOrWhiteSpace(dto.Type))
+            {
+                _notifier.NotifyWarning(_resources.GetString("TypeRequired") ?? "Type is required");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(dto.Name))
+            {
+                _notifier.NotifyWarning(_resources.GetString("NameRequired") ?? "Name is required");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(dto.Printery))
+            {
+                _notifier.NotifyWarning(_resources.GetString("PrinteryRequired") ?? "Printery is required");
+                return false;
+            }
+
             if (!int.TryParse(PageNumTextBox.Text, out var pages))
             {
                 _notifier.NotifyWarning(_resources.GetString("PagesParseError") ?? "Error");

--- a/src/Publishing.UI/Forms/LoginForm.cs
+++ b/src/Publishing.UI/Forms/LoginForm.cs
@@ -2,6 +2,7 @@ using System;
 using Publishing.Core.Interfaces;
 using Publishing.Services;
 using System.Resources;
+using System.Net.Mail;
 using System.Windows.Forms;
 
 namespace Publishing
@@ -31,6 +32,26 @@ namespace Publishing
         {
             string email = EmailTextBox.Text;
             string password = PasswordTextBox.Text;
+
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                _notifier.NotifyWarning(_notify.GetString("EmailRequired") ?? "Email is required");
+                return;
+            }
+            try
+            {
+                _ = new MailAddress(email);
+            }
+            catch
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidEmailFormat") ?? "Invalid email format");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                _notifier.NotifyWarning(_notify.GetString("PasswordRequired") ?? "Password is required");
+                return;
+            }
 
             var result = await _authService.AuthenticateAsync(email, password);
 

--- a/src/Publishing.UI/Forms/OrganizationForm.cs
+++ b/src/Publishing.UI/Forms/OrganizationForm.cs
@@ -7,6 +7,8 @@ using System.Resources;
 using System.Threading.Tasks;
 using FluentValidation;
 using System.Linq;
+using System.Net.Mail;
+using System.Text.RegularExpressions;
 
 namespace Publishing
 {
@@ -62,6 +64,34 @@ namespace Publishing
                 Fax = FaxTextBox.Text,
                 Address = AddressTextBox.Text
             };
+
+            if (string.IsNullOrWhiteSpace(dto.Name))
+            {
+                _notifier.NotifyWarning(_notify.GetString("OrgNameRequired") ?? "Organization name is required");
+                return;
+            }
+            if (!string.IsNullOrWhiteSpace(dto.Email))
+            {
+                try
+                {
+                    _ = new MailAddress(dto.Email);
+                }
+                catch
+                {
+                    _notifier.NotifyWarning(_notify.GetString("InvalidEmailFormat") ?? "Invalid email format");
+                    return;
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(dto.Phone) && !Regex.IsMatch(dto.Phone, "^\\+?[1-9]\\d{2,14}$"))
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidPhoneFormat") ?? "Invalid phone format");
+                return;
+            }
+            if (!string.IsNullOrWhiteSpace(dto.Fax) && !Regex.IsMatch(dto.Fax, "^\\+?[1-9]\\d{2,14}$"))
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidFaxFormat") ?? "Invalid fax format");
+                return;
+            }
 
             try
             {

--- a/src/Publishing.UI/Forms/ProfileForm.cs
+++ b/src/Publishing.UI/Forms/ProfileForm.cs
@@ -7,6 +7,8 @@ using System.Resources;
 using System.Threading.Tasks;
 using FluentValidation;
 using System.Linq;
+using System.Net.Mail;
+using System.Text.RegularExpressions;
 
 namespace Publishing
 {
@@ -58,6 +60,29 @@ namespace Publishing
                 Fax = FaxTextBox.Text,
                 Address = AddressTextBox.Text
             };
+
+            if (!string.IsNullOrWhiteSpace(dto.Email))
+            {
+                try
+                {
+                    _ = new MailAddress(dto.Email);
+                }
+                catch
+                {
+                    _notifier.NotifyWarning(_notify.GetString("InvalidEmailFormat") ?? "Invalid email format");
+                    return;
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(dto.Phone) && !Regex.IsMatch(dto.Phone, "^\\+?[1-9]\\d{2,14}$"))
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidPhoneFormat") ?? "Invalid phone format");
+                return;
+            }
+            if (!string.IsNullOrWhiteSpace(dto.Fax) && !Regex.IsMatch(dto.Fax, "^\\+?[1-9]\\d{2,14}$"))
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidFaxFormat") ?? "Invalid fax format");
+                return;
+            }
 
             try
             {

--- a/src/Publishing.UI/Forms/RegistrationForm.cs
+++ b/src/Publishing.UI/Forms/RegistrationForm.cs
@@ -6,6 +6,7 @@ using Publishing.Core.DTOs;
 using Publishing.Services;
 using System.Threading.Tasks;
 using System.Resources;
+using System.Net.Mail;
 
 namespace Publishing
 {
@@ -47,6 +48,41 @@ namespace Publishing
                 Status = StatusBox.SelectedItem?.ToString(),
                 Password = PasswordTextBox.Text
             };
+
+            if (string.IsNullOrWhiteSpace(dto.FirstName))
+            {
+                _notifier.NotifyWarning(_notify.GetString("FirstNameRequired") ?? "First name is required");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dto.LastName))
+            {
+                _notifier.NotifyWarning(_notify.GetString("LastNameRequired") ?? "Last name is required");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dto.Email))
+            {
+                _notifier.NotifyWarning(_notify.GetString("EmailRequired") ?? "Email is required");
+                return;
+            }
+            try
+            {
+                _ = new MailAddress(dto.Email);
+            }
+            catch
+            {
+                _notifier.NotifyWarning(_notify.GetString("InvalidEmailFormat") ?? "Invalid email format");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dto.Status))
+            {
+                _notifier.NotifyWarning(_notify.GetString("StatusRequired") ?? "Status is required");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dto.Password))
+            {
+                _notifier.NotifyWarning(_notify.GetString("PasswordRequired") ?? "Password is required");
+                return;
+            }
 
             try
             {

--- a/src/Publishing.UI/Resources/Resources.en.resx
+++ b/src/Publishing.UI/Resources/Resources.en.resx
@@ -15,4 +15,13 @@
   <data name="TotalPriceLabel" xml:space="preserve">
     <value>Total price: {0}</value>
   </data>
+  <data name="TypeRequired" xml:space="preserve">
+    <value>Select type</value>
+  </data>
+  <data name="NameRequired" xml:space="preserve">
+    <value>Name is required</value>
+  </data>
+  <data name="PrinteryRequired" xml:space="preserve">
+    <value>Select printery</value>
+  </data>
 </root>

--- a/src/Publishing.UI/Resources/Resources.resx
+++ b/src/Publishing.UI/Resources/Resources.resx
@@ -15,4 +15,13 @@
   <data name="TotalPriceLabel" xml:space="preserve">
     <value>Кінцева ціна: {0}</value>
   </data>
+  <data name="TypeRequired" xml:space="preserve">
+    <value>Потрібно вибрати тип</value>
+  </data>
+  <data name="NameRequired" xml:space="preserve">
+    <value>Потрібна назва</value>
+  </data>
+  <data name="PrinteryRequired" xml:space="preserve">
+    <value>Потрібно вибрати друкарню</value>
+  </data>
 </root>

--- a/src/Publishing.UI/Resources/Resources.uk.resx
+++ b/src/Publishing.UI/Resources/Resources.uk.resx
@@ -15,4 +15,13 @@
   <data name="TotalPriceLabel" xml:space="preserve">
     <value>Кінцева ціна: {0}</value>
   </data>
+  <data name="TypeRequired" xml:space="preserve">
+    <value>Потрібно вибрати тип</value>
+  </data>
+  <data name="NameRequired" xml:space="preserve">
+    <value>Потрібна назва</value>
+  </data>
+  <data name="PrinteryRequired" xml:space="preserve">
+    <value>Потрібно вибрати друкарню</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add per-field validation strings in resources
- validate user input in login, registration and profile forms
- check organization info fields before update
- require mandatory fields when creating orders
- provide custom validator messages for DTOs and commands

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f3c8f108320b9163e7e7ae272f1