### PR TITLE
Fix tests by setting CONSUL_URL

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -12,6 +12,7 @@ public class AggregationE2ETests : IClassFixture<WebApplicationFactory<Program>>
 
     public AggregationE2ETests(WebApplicationFactory<Program> factory)
     {
+        Environment.SetEnvironmentVariable("CONSUL_URL", "http://consul");
         _factory = factory.WithWebHostBuilder(builder => { });
     }
 

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -36,6 +36,7 @@ public class GatewayAggregationTests
 {
     private WebApplicationFactory<Program> CreateFactory()
     {
+        Environment.SetEnvironmentVariable("CONSUL_URL", "http://consul");
         return new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {


### PR DESCRIPTION
## Summary
- set `CONSUL_URL` inside integration tests
- set `CONSUL_URL` inside e2e tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e31b1ce708320b27351d4d3e3996b