### PR TITLE
Fix missing using in AggregationE2ETests

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;


### PR DESCRIPTION
## Summary
- fix compile error in E2E tests by adding `using System;`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e346f4e908320946ac9f3997dee7d