### PR TITLE
Fix E2E tests setup

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -14,6 +14,9 @@ public class AggregationE2ETests : IClassFixture<WebApplicationFactory<Program>>
     public AggregationE2ETests(WebApplicationFactory<Program> factory)
     {
         Environment.SetEnvironmentVariable("CONSUL_URL", "http://consul");
+        Environment.SetEnvironmentVariable("REDIS_CONN", "localhost");
+        Environment.SetEnvironmentVariable("OIDC_AUTHORITY", "http://auth");
+        Environment.SetEnvironmentVariable("OIDC_AUDIENCE", "audience");
         _factory = factory.WithWebHostBuilder(builder => { });
     }
 


### PR DESCRIPTION
## Summary
- fix `AggregationE2ETests` by supplying required environment variables

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3575f9e08320a082143c146a7538