### PR TITLE
Fix DI in gateway tests

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 using ApiGateway;
+using Publishing.Core.Interfaces;
+using Publishing.Infrastructure;
 
 namespace Publishing.E2E.Tests;
 
@@ -17,7 +19,13 @@ public class AggregationE2ETests : IClassFixture<WebApplicationFactory<Program>>
         Environment.SetEnvironmentVariable("REDIS_CONN", "localhost");
         Environment.SetEnvironmentVariable("OIDC_AUTHORITY", "http://auth");
         Environment.SetEnvironmentVariable("OIDC_AUDIENCE", "audience");
-        _factory = factory.WithWebHostBuilder(builder => { });
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddTransient<ILogger, LoggerService>();
+            });
+        });
     }
 
     [Fact]

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -9,6 +9,8 @@ using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Logging;
+using Publishing.Core.Interfaces;
+using Publishing.Infrastructure;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
@@ -48,6 +50,7 @@ public class GatewayAggregationTests
                 {
                     services.AddAuthentication("Test")
                         .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+                    services.AddTransient<ILogger, LoggerService>();
                     services.AddHttpClient("orders").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("[]"));
                     services.AddHttpClient("profile").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("{}"));
                     services.AddHttpClient("organization").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("{}"));


### PR DESCRIPTION
## Summary
- register `LoggerService` in Gateway aggregation tests
- register `LoggerService` in E2E aggregation tests to satisfy `ErrorHandler` dependencies

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e385493088320a69bce095e11cbb2