### PR TITLE
Fix AddTransient usage in tests

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using ApiGateway;
 using Publishing.Core.Interfaces;
 using Publishing.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Publishing.E2E.Tests;
 

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Logging;
 using Publishing.Core.Interfaces;
+using CoreLogger = Publishing.Core.Interfaces.ILogger;
 using Publishing.Infrastructure;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
@@ -50,7 +51,7 @@ public class GatewayAggregationTests
                 {
                     services.AddAuthentication("Test")
                         .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
-                    services.AddTransient<ILogger, LoggerService>();
+                    services.AddTransient<CoreLogger, LoggerService>();
                     services.AddHttpClient("orders").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("[]"));
                     services.AddHttpClient("profile").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("{}"));
                     services.AddHttpClient("organization").ConfigurePrimaryHttpMessageHandler(() => new StubHandler("{}"));


### PR DESCRIPTION
## Summary
- import `Microsoft.Extensions.DependencyInjection` for E2E test
- disambiguate `ILogger` usage in `GatewayAggregationTests`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e399662b48320988905c857bb732b