### PR TITLE
Fix tests by disabling Consul

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -115,7 +115,8 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseSwagger();
 app.UseSwaggerUI();
-await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
+if (!app.Environment.IsEnvironment("Test"))
+    await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 await app.UseOcelot();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -191,7 +191,8 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
+if (!app.Environment.IsEnvironment("Test"))
+    await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -147,7 +147,8 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
+if (!app.Environment.IsEnvironment("Test"))
+    await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 
 // Map health check endpoint so Docker can check container status

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -147,7 +147,8 @@ app.UseCors();
 app.UseExceptionHandling();
 app.UseAuthentication();
 app.UseAuthorization();
-await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
+if (!app.Environment.IsEnvironment("Test"))
+    await app.RegisterWithConsulAsync(app.Lifetime, app.Configuration);
 app.MapControllers();
 app.MapHealthChecks("/health");
 app.UseOpenTelemetryPrometheusScrapingEndpoint();

--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -17,6 +17,7 @@ public class AggregationE2ETests : IClassFixture<WebApplicationFactory<Program>>
     public AggregationE2ETests(WebApplicationFactory<Program> factory)
     {
         Environment.SetEnvironmentVariable("CONSUL_URL", "http://consul");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
         Environment.SetEnvironmentVariable("REDIS_CONN", "localhost");
         Environment.SetEnvironmentVariable("OIDC_AUTHORITY", "http://auth");
         Environment.SetEnvironmentVariable("OIDC_AUDIENCE", "audience");

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -40,6 +40,7 @@ public class GatewayAggregationTests
     private WebApplicationFactory<Program> CreateFactory()
     {
         Environment.SetEnvironmentVariable("CONSUL_URL", "http://consul");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
         Environment.SetEnvironmentVariable("REDIS_CONN", "localhost");
         Environment.SetEnvironmentVariable("OIDC_AUTHORITY", "http://auth");
         Environment.SetEnvironmentVariable("OIDC_AUDIENCE", "aud");


### PR DESCRIPTION
## Summary
- disable Consul registration when running tests
- set ASPNETCORE_ENVIRONMENT to `Test` in integration and E2E tests so Consul is skipped

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3ac142048320bd45d01ae8782e16