### PR TITLE
Fix tests by setting Test environment

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -23,6 +23,7 @@ public class AggregationE2ETests : IClassFixture<WebApplicationFactory<Program>>
         Environment.SetEnvironmentVariable("OIDC_AUDIENCE", "audience");
         _factory = factory.WithWebHostBuilder(builder =>
         {
+            builder.UseEnvironment("Test");
             builder.ConfigureServices(services =>
             {
                 services.AddTransient<ILogger, LoggerService>();

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -48,6 +48,7 @@ public class GatewayAggregationTests
         return new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
+                builder.UseEnvironment("Test");
                 builder.ConfigureServices(services =>
                 {
                     services.AddAuthentication("Test")


### PR DESCRIPTION
## Summary
- ensure tests run with `Test` ASP.NET environment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3d971afc8320be3594b108e44176