### PR TITLE
Fix WebHostBuilder extension usage

### DIFF
--- a/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
+++ b/src/tests/Publishing.E2E.Tests/AggregationE2ETests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
 using Xunit;
 using ApiGateway;
 using Publishing.Core.Interfaces;

--- a/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
+++ b/src/tests/Publishing.Integration.Tests/GatewayAggregationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
 using ApiGateway;
 using System.Net.Http;
 using System.Net;


### PR DESCRIPTION
## Summary
- ensure `UseEnvironment` extension available by importing `Microsoft.AspNetCore.Hosting`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3e5d230c8320804711705335af15