### PR TITLE
Fix ApiGateway build by removing namespace

### DIFF
--- a/src/ApiGateway/Program.cs
+++ b/src/ApiGateway/Program.cs
@@ -22,8 +22,6 @@ using HealthChecks.Uris;
 using System.Net;
 using System.Net.Http;
 
-namespace ApiGateway;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("ocelot.json", optional: false, reloadOnChange: true);


### PR DESCRIPTION
## Summary
- remove file-scoped namespace from `Program.cs` so top-level statements compile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e3faf978c8320845219ba4538b855