### PR TITLE
Add SQL connection retry

### DIFF
--- a/src/Publishing.Orders.Service/Program.cs
+++ b/src/Publishing.Orders.Service/Program.cs
@@ -156,7 +156,9 @@ var conn = builder.Configuration["ORDERS_DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("ORDERS_DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
-    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+    o.UseSqlServer(conn, b =>
+        b.MigrationsAssembly("Publishing.Infrastructure")
+         .EnableRetryOnFailure()));
 
 var healthChecks = builder.Services
     .AddHealthChecks()

--- a/src/Publishing.Organization.Service/Program.cs
+++ b/src/Publishing.Organization.Service/Program.cs
@@ -123,7 +123,9 @@ var conn = builder.Configuration["ORGANIZATION_DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("ORGANIZATION_DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
-    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+    o.UseSqlServer(conn, b =>
+        b.MigrationsAssembly("Publishing.Infrastructure")
+         .EnableRetryOnFailure()));
 
 builder.Services
     .AddHealthChecks()

--- a/src/Publishing.Profile.Service/Program.cs
+++ b/src/Publishing.Profile.Service/Program.cs
@@ -123,7 +123,9 @@ var conn = builder.Configuration["PROFILE_DB_CONN"];
 if (string.IsNullOrWhiteSpace(conn))
     throw new InvalidOperationException("PROFILE_DB_CONN environment variable is missing");
 builder.Services.AddDbContext<AppDbContext>(o =>
-    o.UseSqlServer(conn, b => b.MigrationsAssembly("Publishing.Infrastructure")));
+    o.UseSqlServer(conn, b =>
+        b.MigrationsAssembly("Publishing.Infrastructure")
+         .EnableRetryOnFailure()));
 
 var healthChecks = builder.Services
     .AddHealthChecks()

--- a/src/Publishing.UI/Program.cs
+++ b/src/Publishing.UI/Program.cs
@@ -92,7 +92,8 @@ namespace Publishing
             services.AddDbContext<AppDbContext>(o =>
                 o.UseSqlServer(
                     configuration.GetConnectionString("DefaultConnection"),
-                    b => b.MigrationsAssembly("Publishing.Infrastructure")));
+                    b => b.MigrationsAssembly("Publishing.Infrastructure")
+                          .EnableRetryOnFailure()));
             services.AddTransient<IDbConnectionFactory, SqlDbConnectionFactory>();
             services.AddSingleton<QueryDispatcher>();
             services.AddSingleton<IQueryDispatcher>(sp =>


### PR DESCRIPTION
## Summary
- add `EnableRetryOnFailure` when configuring SQL Server contexts

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e40dea22c8320a825d12f6be1b5dc