### PR TITLE
Add gateway health endpoint check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,10 +140,11 @@ services:
       rabbit:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
-      interval: 10s
+      test: ["CMD-SHELL", "curl -f http://localhost/health || exit 1"]
+      interval: 30s
       timeout: 5s
-      retries: 5
+      retries: 3
+      start_period: 15s
     networks:
       - micro-net
 


### PR DESCRIPTION
## Summary
- expose /health endpoint for ApiGateway
- update Gateway healthcheck to use the endpoint

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e547d08dc83209575b835c8294a93