### PR TITLE
Fix gateway healthcheck start time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 15s
+      start_period: 30s
     networks:
       - micro-net
 


### PR DESCRIPTION
## Summary
- adjust `gateway` healthcheck start period to allow more startup time

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e764f3f9083209f79d1bac1c32ce7