### PR TITLE
Fix active orders query to include InProgress

### DIFF
--- a/src/Publishing.Infrastructure/DataAccess/GetActiveOrdersQuery.cs
+++ b/src/Publishing.Infrastructure/DataAccess/GetActiveOrdersQuery.cs
@@ -8,7 +8,7 @@ public sealed class GetActiveOrdersQuery : SqlQuery<Order>
     public override string Sql =>
         @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price
           FROM (Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct)
-          INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder = 'в роботі' ORDER BY O.dateOrder";
+          INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder IN ('в роботі', 'InProgress') ORDER BY O.dateOrder";
 
     public override Order Map(IDataReader reader)
     {

--- a/src/Publishing.Infrastructure/Queries/OrderQueries.cs
+++ b/src/Publishing.Infrastructure/Queries/OrderQueries.cs
@@ -14,7 +14,7 @@ namespace Publishing.Infrastructure.Queries
 
         public Task<DataTable> GetActiveAsync()
         {
-            const string sql = @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price FROM(Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct ) INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder = 'в роботі' ORDER BY O.dateOrder";
+            const string sql = @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price FROM(Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct ) INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder IN ('в роботі', 'InProgress') ORDER BY O.dateOrder";
             return _helper.QueryDataTableAsync(sql);
         }
 

--- a/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Publishing.Infrastructure/Repositories/OrderRepository.cs
@@ -117,7 +117,7 @@ namespace Publishing.Infrastructure.Repositories
 
         public Task<DataTable> GetActiveAsync()
         {
-            const string sql = @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price FROM(Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct ) INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder = 'в роботі' ORDER BY O.dateOrder";
+            const string sql = @"SELECT O.namePrintery, Prod.typeProduct, Prod.nameProduct, Per.FName, Per.LName, O.dateOrder, O.dateStart, O.dateFinish, O.statusOrder, O.price FROM(Orders O INNER JOIN Product Prod ON Prod.idProduct = O.idProduct ) INNER JOIN Person Per ON Per.idPerson = Prod.idPerson WHERE O.statusOrder IN ('в роботі', 'InProgress') ORDER BY O.dateOrder";
             return _helper.QueryDataTableAsync(sql);
         }
 


### PR DESCRIPTION
## Summary
- show orders with status `InProgress` on the main form

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e7e764a8c83209581f7a5498fe588